### PR TITLE
[New] add `isValidElement` entry point

### DIFF
--- a/__tests__/isValidElement-test.js
+++ b/__tests__/isValidElement-test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var React = require('react');
+var isValidElement = require('../isValidElement');
+
+describe('isValidElement', () => {
+  class Component extends React.Component {
+    render() {
+      return <div />;
+    }
+  }
+
+  function SFC() {
+    return <div />;
+  }
+
+  it('should support components', () => {
+    expect(isValidElement(<div />)).toBe(true);
+    expect(isValidElement(<Component />)).toBe(true);
+    expect(isValidElement(<SFC />)).toBe(true);
+  });
+
+  it('should not support multiple components or scalar values', () => {
+    expect(isValidElement([<div />, <div />])).toBe(false);
+    expect(isValidElement(123)).toBe(false);
+    expect(isValidElement('foo')).toBe(false);
+    expect(isValidElement(false)).toBe(false);
+    expect(isValidElement(null)).toBe(false);
+    expect(isValidElement(undefined)).toBe(false);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -8,16 +8,7 @@
  */
 
 if (process.env.NODE_ENV !== 'production') {
-  var REACT_ELEMENT_TYPE = (typeof Symbol === 'function' &&
-    Symbol.for &&
-    Symbol.for('react.element')) ||
-    0xeac7;
-
-  var isValidElement = function(object) {
-    return typeof object === 'object' &&
-      object !== null &&
-      object.$$typeof === REACT_ELEMENT_TYPE;
-  };
+  var isValidElement = require('./isValidElement');
 
   // By explicitly using `prop-types` you are opting into new development behavior.
   // http://fb.me/prop-types-in-prod

--- a/isValidElement.js
+++ b/isValidElement.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+var REACT_ELEMENT_TYPE = (typeof Symbol === 'function' &&
+  Symbol.for &&
+  Symbol.for('react.element')) ||
+  0xeac7;
+
+module.exports = function isValidElement(object) {
+  return object !== null &&
+    typeof object === 'object' &&
+    object.$$typeof === REACT_ELEMENT_TYPE;
+}


### PR DESCRIPTION
Fixes #1.

I think a much better approach, however, would be to make `isValidElement` a separate package too, like `prop-types` - happy to close this PR in place of that :-)