### PR TITLE
Added a bit more info to the warning when failing a type union check

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -864,7 +864,7 @@ describe('PropTypesDevelopmentReact15', () => {
       typeCheckFail(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         [],
-        'Invalid prop `testProp` supplied to `testComponent`.',
+        'Invalid prop `testProp` supplied to `testComponent`, failed matches:',
       );
 
       var checker = PropTypes.oneOfType([
@@ -874,7 +874,7 @@ describe('PropTypesDevelopmentReact15', () => {
       typeCheckFail(
         checker,
         {c: 1},
-        'Invalid prop `testProp` supplied to `testComponent`.',
+        'Invalid prop `testProp` supplied to `testComponent`, failed matches:',
       );
     });
 

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -860,7 +860,7 @@ describe('PropTypesDevelopmentStandalone', () => {
       typeCheckFail(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         [],
-        'Invalid prop `testProp` supplied to `testComponent`.',
+        'Invalid prop `testProp` supplied to `testComponent`, failed matches:',
       );
 
       var checker = PropTypes.oneOfType([
@@ -870,7 +870,7 @@ describe('PropTypesDevelopmentStandalone', () => {
       typeCheckFail(
         checker,
         {c: 1},
-        'Invalid prop `testProp` supplied to `testComponent`.',
+        'Invalid prop `testProp` supplied to `testComponent`, failed matches:',
       );
     });
 

--- a/__tests__/PropTypesProductionReact15-test.js
+++ b/__tests__/PropTypesProductionReact15-test.js
@@ -18,7 +18,7 @@ function resetWarningCache() {
   jest.resetModules();
 
   // Set production mode throughout this test.
-  process.env.NODE_ENV = 'production';  
+  process.env.NODE_ENV = 'production';
   React = require('react');
   // We are testing that when imported in the same way React 15 imports `prop-types`,
   // it just suppresses warnings but doesn't actually throw when calling validators.
@@ -759,7 +759,7 @@ describe('PropTypesProductionReact15', () => {
       expectNoop(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         [],
-        'Invalid prop `testProp` supplied to `testComponent`.',
+        'Invalid prop `testProp` supplied to `testComponent`, failed matches:',
       );
 
       var checker = PropTypes.oneOfType([
@@ -769,7 +769,7 @@ describe('PropTypesProductionReact15', () => {
       expectNoop(
         checker,
         {c: 1},
-        'Invalid prop `testProp` supplied to `testComponent`.',
+        'Invalid prop `testProp` supplied to `testComponent`, failed matches:',
       );
     });
 

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -321,14 +321,17 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
     }
 
     function validate(props, propName, componentName, location, propFullName) {
+      var messages = [];
       for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
         var checker = arrayOfTypeCheckers[i];
-        if (checker(props, propName, componentName, location, propFullName, ReactPropTypesSecret) == null) {
+        var error = checker(props, propName, componentName, location, propFullName, ReactPropTypesSecret);
+        if (error == null) {
           return null;
         }
+        messages.push(error.message);
       }
 
-      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`.'));
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`, failed matches:\n' + messages.join('\n')));
     }
     return createChainableTypeChecker(validate);
   }


### PR DESCRIPTION
I found the warning from type union failures to be uninformative and so have tried to improve them. 
I've changed the message to append the failure messages from each of the types on new lines so rather than just seeing that the prop type was wrong you can see what it was trying to match against.