### PR TITLE
Validating if the arguments passed to oneOf is not a function 

### DIFF
--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -277,6 +277,15 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       return emptyFunction.thatReturnsNull;
     }
 
+    function isValueAFunction(value) {
+      return typeof value === 'function'
+    }
+
+    if (expectedValues.every(isValueAFunction)) {
+      process.env.NODE_ENV !== 'production' ? warning(false, 'Invalid argument supplied to oneOf, expected an array of values but got an array of PropType functions. Did you mean oneOfType?') : void 0;
+      return emptyFunction.thatReturnsNull;
+    }
+
     function validate(props, propName, componentName, location, propFullName) {
       var propValue = props[propName];
       for (var i = 0; i < expectedValues.length; i++) {


### PR DESCRIPTION
Warn if mistakenly oneOf has been used instead of oneOfType.

Fixes issue [9](https://github.com/reactjs/prop-types/issues/9) (Main reported issue -  [facebook/react#1919](https://github.com/facebook/react/issues/1919))