### PR TITLE
Friendlier message when using a type checker that is not a function

### DIFF
--- a/checkPropTypes.js
+++ b/checkPropTypes.js
@@ -53,7 +53,8 @@ function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
           if (typeof typeSpecs[typeSpecName] !== 'function') {
             var err = Error(
               (componentName || 'React class') + ': ' + location + ' type `' + typeSpecName + '` is invalid; ' +
-              'it must be a function, usually from the `prop-types` package, but received `' + typeof typeSpecs[typeSpecName] + '`.'
+              'it must be a function, usually from the `prop-types` package, but received `' + typeof typeSpecs[typeSpecName] + '`.' +
+              'This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.'
             );
             err.name = 'Invariant Violation';
             throw err;


### PR DESCRIPTION
Just a text change, adds a stronger hint as to the most common issue.
This tries to prevent confusion as discussed in #33 

Sample:

```
> PropTypes.checkPropTypes({pname: PropTypes.stringzz}, {pname: false}, 'prop', 'MyCompo')
Warning: Failed prop type: MyCompo: type specification of prop `pname` is invalid; the type checker must be a function but is `undefined`. This often happens because of typos such as `React.PropTypes.function` instead of `React.PropTypes.func`.
```

Fixes #33.