### PR TITLE
Enhance warning message when a PropType is not correct

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -150,6 +150,20 @@ describe('PropTypesDevelopmentReact15', () => {
       expect(console.error.calls.argsFor(0)[0]).toContain('some error');
       expect(returnValue).toBe(undefined);
     });
+
+    it('warns if any of the propTypes is not a function', () => {
+      spyOn(console, 'error');
+      const propTypes = {
+        foo: PropTypes.invalid_type,
+      };
+      const props = { foo: 'foo' };
+      const returnValue = PropTypes.checkPropTypes(propTypes, props, 'prop', 'testComponent', null);
+      expect(console.error.calls.argsFor(0)[0]).toEqual(
+        'Warning: Failed prop type: testComponent: prop type `foo` is invalid; '
+        + 'it must be a function, usually from React.PropTypes, but received `undefined`.'
+      );
+      expect(returnValue).toBe(undefined);
+    });
   });
 
   describe('Primitive Types', () => {

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -146,6 +146,20 @@ describe('PropTypesDevelopmentStandalone', () => {
       expect(console.error.calls.argsFor(0)[0]).toContain('some error');
       expect(returnValue).toBe(undefined);
     });
+
+    it('warns if any of the propTypes is not a function', () => {
+      spyOn(console, 'error');
+      const propTypes = {
+        foo: PropTypes.invalid_type,
+      };
+      const props = { foo: 'foo' };
+      const returnValue = PropTypes.checkPropTypes(propTypes, props, 'prop', 'testComponent', null);
+      expect(console.error.calls.argsFor(0)[0]).toEqual(
+        'Warning: Failed prop type: testComponent: prop type `foo` is invalid; '
+        + 'it must be a function, usually from React.PropTypes, but received `undefined`.'
+      );
+      expect(returnValue).toBe(undefined);
+    });
   });
 
   describe('Primitive Types', () => {

--- a/checkPropTypes.js
+++ b/checkPropTypes.js
@@ -38,7 +38,7 @@ function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
         try {
           // This is intentionally an invariant that gets caught. It's the same
           // behavior as without this statement except with a better message.
-          invariant(typeof typeSpecs[typeSpecName] === 'function', '%s: %s type `%s` is invalid; it must be a function, usually from ' + 'React.PropTypes.', componentName || 'React class', location, typeSpecName);
+          invariant(typeof typeSpecs[typeSpecName] === 'function', '%s: %s type `%s` is invalid; it must be a function, usually from ' + 'React.PropTypes, but received `%s`.', componentName || 'React class', location, typeSpecName, typeof typeSpecs[typeSpecName]);
           error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
         } catch (ex) {
           error = ex;


### PR DESCRIPTION
Closes https://github.com/facebook/react/issues/9068 that got already closed when prop-types was moved. There was another PR (https://github.com/facebook/react/pull/9140) for the same purpose that also got closed for the same reason.

CC @gaearon as he participated in https://github.com/facebook/react/pull/9140

Thanks.