### PR TITLE
Update error message to point to prop-types package

### DIFF
--- a/checkPropTypes.js
+++ b/checkPropTypes.js
@@ -38,7 +38,7 @@ function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
         try {
           // This is intentionally an invariant that gets caught. It's the same
           // behavior as without this statement except with a better message.
-          invariant(typeof typeSpecs[typeSpecName] === 'function', '%s: %s type `%s` is invalid; it must be a function, usually from ' + 'React.PropTypes.', componentName || 'React class', location, typeSpecName);
+          invariant(typeof typeSpecs[typeSpecName] === 'function', '%s: %s type `%s` is invalid; it must be a function, usually from ' + 'the `prop-types` package.', componentName || 'React class', location, typeSpecName);
           error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
         } catch (ex) {
           error = ex;


### PR DESCRIPTION
Fixes an outdated error code string that points to `React.PropTypes` rather than the `prop-types` package. As discussed in https://github.com/facebook/react/pull/9842.