### PR TITLE
'jsx' code annotation changed to 'js'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ commonly used with React components.
 Here is an example of using PropTypes with a React component, which also
 documents the different validators provided:
 
-```jsx
+```js
 import React from 'react';
 import PropTypes from 'prop-types';
 


### PR DESCRIPTION
`js` is recognized by npmjs.com (`jsx` isn't) and there was no JSX here anyway.