### PR TITLE
Add test coverage for invalid validator warning

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -113,7 +113,7 @@ describe('PropTypesDevelopmentReact15', () => {
   });
 
   describe('checkPropTypes', () => {
-    it('warn for invalid validators', () => {
+    it('should warn for invalid validators', () => {
       spyOn(console, 'error')
       const propTypes = { foo: undefined };
       const props = { foo: 'foo' };

--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -113,6 +113,23 @@ describe('PropTypesDevelopmentReact15', () => {
   });
 
   describe('checkPropTypes', () => {
+    it('warn for invalid validators', () => {
+      spyOn(console, 'error')
+      const propTypes = { foo: undefined };
+      const props = { foo: 'foo' };
+      PropTypes.checkPropTypes(
+        propTypes,
+        props,
+        'prop',
+        'testComponent',
+        null,
+      );
+      expect(console.error.calls.argsFor(0)[0]).toEqual(
+        'Warning: Failed prop type: testComponent: prop type `foo` is invalid; ' +
+        'it must be a function, usually from the `prop-types` package.'
+      );
+    });
+
     it('does not return a value from a validator', () => {
       spyOn(console, 'error');
       const propTypes = {

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -109,7 +109,7 @@ describe('PropTypesDevelopmentStandalone', () => {
   });
 
   describe('checkPropTypes', () => {
-    it('warn for invalid validators', () => {
+    it('should warn for invalid validators', () => {
       spyOn(console, 'error')
       const propTypes = { foo: undefined };
       const props = { foo: 'foo' };

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -109,6 +109,23 @@ describe('PropTypesDevelopmentStandalone', () => {
   });
 
   describe('checkPropTypes', () => {
+    it('warn for invalid validators', () => {
+      spyOn(console, 'error')
+      const propTypes = { foo: undefined };
+      const props = { foo: 'foo' };
+      PropTypes.checkPropTypes(
+        propTypes,
+        props,
+        'prop',
+        'testComponent',
+        null,
+      );
+      expect(console.error.calls.argsFor(0)[0]).toEqual(
+        'Warning: Failed prop type: testComponent: prop type `foo` is invalid; ' +
+        'it must be a function, usually from the `prop-types` package.'
+      );
+    });
+
     it('does not return a value from a validator', () => {
       spyOn(console, 'error');
       const propTypes = {


### PR DESCRIPTION
This warning was changed in https://github.com/facebook/prop-types/pull/71 and it didn't break any tests. This adds some simple test coverage for this warning.