### PR TITLE
Improve invalid type warnings

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -114,20 +114,25 @@ describe('PropTypesDevelopmentReact15', () => {
 
   describe('checkPropTypes', () => {
     it('should warn for invalid validators', () => {
+      var types = [undefined, null, false, new Date, /foo/, {}];
+      var expected = ['`undefined`', '`null`', 'a boolean', 'a date', 'a regexp', 'an object'];
       spyOn(console, 'error')
-      const propTypes = { foo: undefined };
       const props = { foo: 'foo' };
-      PropTypes.checkPropTypes(
-        propTypes,
-        props,
-        'prop',
-        'testComponent',
-        null,
-      );
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Failed prop type: testComponent: prop type `foo` is invalid; ' +
-        'it must be a function, usually from the `prop-types` package.'
-      );
+      for (var i = 0; i < types.length; i++) {
+        const propTypes = { foo: types[i] };
+        PropTypes.checkPropTypes(
+          propTypes,
+          props,
+          'prop',
+          'testComponent',
+          null,
+        );
+        expect(console.error.calls.argsFor(0)[0]).toEqual(
+          'Warning: Failed prop type: testComponent: prop type `foo` is invalid. ' +
+          'Expected a function, usually from the `prop-types` package, but received ' + expected[i] + ' instead.'
+        );
+        console.error.calls.reset();
+      }
     });
 
     it('does not return a value from a validator', () => {
@@ -165,20 +170,6 @@ describe('PropTypesDevelopmentReact15', () => {
         null,
       );
       expect(console.error.calls.argsFor(0)[0]).toContain('some error');
-      expect(returnValue).toBe(undefined);
-    });
-
-    it('warns if any of the propTypes is not a function', () => {
-      spyOn(console, 'error');
-      const propTypes = {
-        foo: PropTypes.invalid_type,
-      };
-      const props = { foo: 'foo' };
-      const returnValue = PropTypes.checkPropTypes(propTypes, props, 'prop', 'testComponent', null);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Failed prop type: testComponent: prop type `foo` is invalid; '
-        + 'it must be a function, usually from the `prop-types` package, but received `undefined`.'
-      );
       expect(returnValue).toBe(undefined);
     });
   });
@@ -895,7 +886,7 @@ describe('PropTypesDevelopmentReact15', () => {
       spyOn(console, 'error');
 
       var types = [undefined, null, false, new Date, /foo/, {}];
-      var expected = ['undefined', 'null', 'a boolean', 'a date', 'a regexp', 'an object'];
+      var expected = ['`undefined`', '`null`', 'a boolean', 'a date', 'a regexp', 'an object'];
 
       for (var i = 0; i < expected.length; i++) {
         var type = types[i];

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -110,20 +110,25 @@ describe('PropTypesDevelopmentStandalone', () => {
 
   describe('checkPropTypes', () => {
     it('should warn for invalid validators', () => {
+      var types = [undefined, null, false, new Date, /foo/, {}];
+      var expected = ['`undefined`', '`null`', 'a boolean', 'a date', 'a regexp', 'an object'];
       spyOn(console, 'error')
-      const propTypes = { foo: undefined };
       const props = { foo: 'foo' };
-      PropTypes.checkPropTypes(
-        propTypes,
-        props,
-        'prop',
-        'testComponent',
-        null,
-      );
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Failed prop type: testComponent: prop type `foo` is invalid; ' +
-        'it must be a function, usually from the `prop-types` package.'
-      );
+      for (var i = 0; i < types.length; i++) {
+        const propTypes = { foo: types[i] };
+        PropTypes.checkPropTypes(
+          propTypes,
+          props,
+          'prop',
+          'testComponent',
+          null,
+        );
+        expect(console.error.calls.argsFor(0)[0]).toEqual(
+          'Warning: Failed prop type: testComponent: prop type `foo` is invalid. ' +
+          'Expected a function, usually from the `prop-types` package, but received ' + expected[i] + ' instead.'
+        );
+        console.error.calls.reset();
+      }
     });
 
     it('does not return a value from a validator', () => {
@@ -161,20 +166,6 @@ describe('PropTypesDevelopmentStandalone', () => {
         null,
       );
       expect(console.error.calls.argsFor(0)[0]).toContain('some error');
-      expect(returnValue).toBe(undefined);
-    });
-
-    it('warns if any of the propTypes is not a function', () => {
-      spyOn(console, 'error');
-      const propTypes = {
-        foo: PropTypes.invalid_type,
-      };
-      const props = { foo: 'foo' };
-      const returnValue = PropTypes.checkPropTypes(propTypes, props, 'prop', 'testComponent', null);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
-        'Warning: Failed prop type: testComponent: prop type `foo` is invalid; '
-        + 'it must be a function, usually from the `prop-types` package, but received `undefined`.'
-      );
       expect(returnValue).toBe(undefined);
     });
   });
@@ -891,7 +882,7 @@ describe('PropTypesDevelopmentStandalone', () => {
       spyOn(console, 'error');
 
       var types = [undefined, null, false, new Date, /foo/, {}];
-      var expected = ['undefined', 'null', 'a boolean', 'a date', 'a regexp', 'an object'];
+      var expected = ['`undefined`', '`null`', 'a boolean', 'a date', 'a regexp', 'an object'];
 
       for (var i = 0; i < expected.length; i++) {
         var type = types[i];

--- a/checkPropTypes.js
+++ b/checkPropTypes.js
@@ -13,6 +13,7 @@ if (process.env.NODE_ENV !== 'production') {
   var invariant = require('fbjs/lib/invariant');
   var warning = require('fbjs/lib/warning');
   var ReactPropTypesSecret = require('./lib/ReactPropTypesSecret');
+  var {getPostfixForTypeWarning} = require('./lib/TypeWarning');
   var loggedTypeFailures = {};
 }
 
@@ -38,7 +39,15 @@ function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
         try {
           // This is intentionally an invariant that gets caught. It's the same
           // behavior as without this statement except with a better message.
-          invariant(typeof typeSpecs[typeSpecName] === 'function', '%s: %s type `%s` is invalid; it must be a function, usually from ' + 'the `prop-types` package, but received `%s`.', componentName || 'React class', location, typeSpecName, typeof typeSpecs[typeSpecName]);
+          invariant(
+            typeof typeSpecs[typeSpecName] === 'function',
+            '%s: %s type `%s` is invalid. Expected a function, usually from ' +
+            'the `prop-types` package, but received %s instead.',
+            componentName || 'React class',
+            location,
+            typeSpecName,
+            getPostfixForTypeWarning(typeSpecs[typeSpecName])
+          );
           error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
         } catch (ex) {
           error = ex;

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -15,6 +15,11 @@ var warning = require('fbjs/lib/warning');
 var assign = require('object-assign');
 
 var ReactPropTypesSecret = require('./lib/ReactPropTypesSecret');
+var {
+  getPropType,
+  getPreciseType,
+  getPostfixForTypeWarning
+} = require('./lib/TypeWarning');
 var checkPropTypes = require('./checkPropTypes');
 
 module.exports = function(isValidElement, throwOnDirectAccess) {
@@ -455,77 +460,6 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
         return true;
       default:
         return false;
-    }
-  }
-
-  function isSymbol(propType, propValue) {
-    // Native Symbol.
-    if (propType === 'symbol') {
-      return true;
-    }
-
-    // 19.4.3.5 Symbol.prototype[@@toStringTag] === 'Symbol'
-    if (propValue['@@toStringTag'] === 'Symbol') {
-      return true;
-    }
-
-    // Fallback for non-spec compliant Symbols which are polyfilled.
-    if (typeof Symbol === 'function' && propValue instanceof Symbol) {
-      return true;
-    }
-
-    return false;
-  }
-
-  // Equivalent of `typeof` but with special handling for array and regexp.
-  function getPropType(propValue) {
-    var propType = typeof propValue;
-    if (Array.isArray(propValue)) {
-      return 'array';
-    }
-    if (propValue instanceof RegExp) {
-      // Old webkits (at least until Android 4.0) return 'function' rather than
-      // 'object' for typeof a RegExp. We'll normalize this here so that /bla/
-      // passes PropTypes.object.
-      return 'object';
-    }
-    if (isSymbol(propType, propValue)) {
-      return 'symbol';
-    }
-    return propType;
-  }
-
-  // This handles more types than `getPropType`. Only used for error messages.
-  // See `createPrimitiveTypeChecker`.
-  function getPreciseType(propValue) {
-    if (typeof propValue === 'undefined' || propValue === null) {
-      return '' + propValue;
-    }
-    var propType = getPropType(propValue);
-    if (propType === 'object') {
-      if (propValue instanceof Date) {
-        return 'date';
-      } else if (propValue instanceof RegExp) {
-        return 'regexp';
-      }
-    }
-    return propType;
-  }
-
-  // Returns a string that is postfixed to a warning about an invalid type.
-  // For example, "undefined" or "of type array"
-  function getPostfixForTypeWarning(value) {
-    var type = getPreciseType(value);
-    switch (type) {
-      case 'array':
-      case 'object':
-        return 'an ' + type;
-      case 'boolean':
-      case 'date':
-      case 'regexp':
-        return 'a ' + type;
-      default:
-        return type;
     }
   }
 

--- a/lib/TypeWarning.js
+++ b/lib/TypeWarning.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+function isSymbol(propType, propValue) {
+  // Native Symbol.
+  if (propType === 'symbol') {
+    return true;
+  }
+
+  // 19.4.3.5 Symbol.prototype[@@toStringTag] === 'Symbol'
+  if (propValue['@@toStringTag'] === 'Symbol') {
+    return true;
+  }
+
+  // Fallback for non-spec compliant Symbols which are polyfilled.
+  if (typeof Symbol === 'function' && propValue instanceof Symbol) {
+    return true;
+  }
+
+  return false;
+}
+
+  // Equivalent of `typeof` but with special handling for array and regexp.
+function getPropType(propValue) {
+  var propType = typeof propValue;
+  if (Array.isArray(propValue)) {
+    return 'array';
+  }
+  if (propValue instanceof RegExp) {
+    // Old webkits (at least until Android 4.0) return 'function' rather than
+    // 'object' for typeof a RegExp. We'll normalize this here so that /bla/
+    // passes PropTypes.object.
+    return 'object';
+  }
+  if (isSymbol(propType, propValue)) {
+    return 'symbol';
+  }
+  return propType;
+}
+
+function getPreciseType(propValue) {
+  if (typeof propValue === 'undefined' || propValue === null) {
+    return '' + propValue;
+  }
+  var propType = getPropType(propValue);
+  if (propType === 'object') {
+    if (propValue instanceof Date) {
+      return 'date';
+    } else if (propValue instanceof RegExp) {
+      return 'regexp';
+    }
+  }
+  return propType;
+}
+
+  // Returns a string that is postfixed to a warning about an invalid type.
+  // For example, "undefined" or "of type array"
+  function getPostfixForTypeWarning(value) {
+    var type = getPreciseType(value);
+    switch (type) {
+      case 'array':
+      case 'object':
+        return 'an ' + type;
+      case 'string':
+      case 'boolean':
+      case 'date':
+      case 'regexp':
+        return 'a ' + type;
+      default:
+        return '`' + type + '`';
+    }
+  }
+
+  module.exports = {
+    getPropType,
+    getPreciseType,
+    getPostfixForTypeWarning,
+  };
+
+


### PR DESCRIPTION
This is a follow up for #68 

* Move type warning utilities to `TypeWarning` module
* Use `getPostfixForTypeWarning` in the invalid validator check instead of `typeof`
* Improve copy in the invalid validator check
* Improve the type warning postfix by making sure strings are prefixed with "a" and putting backticks around literal values like `undefined` and `null`
* Remove redundant test for invalid validators and add checks for additional types