### PR TITLE
Update README.md with improved importing for CDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,31 @@ import PropTypes from 'prop-types'; // ES6
 var PropTypes = require('prop-types'); // ES5 with npm
 ```
 
-If you prefer a `<script>` tag, you can get it from `window.PropTypes` global:
+### CDN
 
+If you prefer to exclude `prop-types` from your application and use it 
+globally via `window.PropTypes`, the `prop-types` package provides 
+single-file distributions, which are hosted on the following CDNs:
+
+* [**unpkg**](https://unpkg.com/prop-types/)
 ```html
 <!-- development version -->
-<script src="https://unpkg.com/prop-types/prop-types.js"></script>
+<script src="https://unpkg.com/prop-types@15.5/prop-types.js"></script>
 
 <!-- production version -->
-<script src="https://unpkg.com/prop-types/prop-types.min.js"></script>
+<script src="https://unpkg.com/prop-types@15.5/prop-types.js"></script>
 ```
+
+* [**cdnjs**](https://cdnjs.com/libraries/prop-types)
+```html
+<!-- development version -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.5.10/prop-types.js"></script>
+
+<!-- production version -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.5.10/prop-types.min.js"></script>
+```
+
+To load a specific version of `prop-types` replace `15.5.10` with the version number. 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ single-file distributions, which are hosted on the following CDNs:
 <script src="https://unpkg.com/prop-types@15.6/prop-types.js"></script>
 
 <!-- production version -->
-<script src="https://unpkg.com/prop-types@15.6/prop-types.js"></script>
+<script src="https://unpkg.com/prop-types@15.6/prop-types.min.js"></script>
 ```
 
 * [**cdnjs**](https://cdnjs.com/libraries/prop-types)

--- a/README.md
+++ b/README.md
@@ -29,22 +29,22 @@ single-file distributions, which are hosted on the following CDNs:
 * [**unpkg**](https://unpkg.com/prop-types/)
 ```html
 <!-- development version -->
-<script src="https://unpkg.com/prop-types@15.5/prop-types.js"></script>
+<script src="https://unpkg.com/prop-types@15.6/prop-types.js"></script>
 
 <!-- production version -->
-<script src="https://unpkg.com/prop-types@15.5/prop-types.js"></script>
+<script src="https://unpkg.com/prop-types@15.6/prop-types.js"></script>
 ```
 
 * [**cdnjs**](https://cdnjs.com/libraries/prop-types)
 ```html
 <!-- development version -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.5.10/prop-types.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.6.0/prop-types.js"></script>
 
 <!-- production version -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.5.10/prop-types.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.6.0/prop-types.min.js"></script>
 ```
 
-To load a specific version of `prop-types` replace `15.5.10` with the version number. 
+To load a specific version of `prop-types` replace `15.6.0` with the version number. 
 
 ## Usage
 


### PR DESCRIPTION
Ensure both unpkg and cdnjs are listed as CDNs, deprecate existing alias CDN reference in preference for best practice explicit version, and updated wording similar to React documentation.

This PR is recreated because I accidentally deleted original fork.

Reference: #99 

Updates:
* Ensured unpkg first
* Major.minor included for unpkg