### PR TITLE
Give production PropTypes identity

### DIFF
--- a/factoryWithThrowingShims.js
+++ b/factoryWithThrowingShims.js
@@ -14,38 +14,41 @@ var invariant = require('fbjs/lib/invariant');
 var ReactPropTypesSecret = require('./lib/ReactPropTypesSecret');
 
 module.exports = function() {
-  function shim(props, propName, componentName, location, propFullName, secret) {
-    if (secret === ReactPropTypesSecret) {
-      // It is still safe when called from React.
-      return;
-    }
-    invariant(
-      false,
-      'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
-      'Use PropTypes.checkPropTypes() to call them. ' +
-      'Read more at http://fb.me/use-check-prop-types'
-    );
-  };
-  shim.isRequired = shim;
+  function shim() {
+    function shimInstance(props, propName, componentName, location, propFullName, secret) {
+      if (secret === ReactPropTypesSecret) {
+        // It is still safe when called from React.
+        return;
+      }
+      invariant(
+        false,
+        'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
+        'Use PropTypes.checkPropTypes() to call them. ' +
+        'Read more at http://fb.me/use-check-prop-types'
+      );
+    };
+    shimInstance.isRequired = shimInstance;
+    return shimInstance;
+  }
   function getShim() {
-    return shim;
+    return shim();
   };
   // Important!
   // Keep this list in sync with production version in `./factoryWithTypeCheckers.js`.
   var ReactPropTypes = {
-    array: shim,
-    bool: shim,
-    func: shim,
-    number: shim,
-    object: shim,
-    string: shim,
-    symbol: shim,
+    array: shim(),
+    bool: shim(),
+    func: shim(),
+    number: shim(),
+    object: shim(),
+    string: shim(),
+    symbol: shim(),
 
-    any: shim,
+    any: shim(),
     arrayOf: getShim,
-    element: shim,
+    element: shim(),
     instanceOf: getShim,
-    node: shim,
+    node: shim(),
     objectOf: getShim,
     oneOf: getShim,
     oneOfType: getShim,


### PR DESCRIPTION
As part of code that renders a user entered string of HTML+JSX(ish) tags I'm using the PropTypes of components to cast attribute values to the appropriate type. E.g. `if (propType === PropTypes.number)                   value = Number(value);`
Since upgrading to this separate prop-types module this is failing as all `PropTypes` are the same `shim` in production and hence are all equal. 

To fix this I have made each `shim` a separate instance so that it has identity.