### PR TITLE
Add `CONTRIBUTING` and `CODE_OF_CONDUCT`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to prop-types
+We want to make contributing to this project as easy and transparent as
+possible.
+
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Pull Requests
+We actively welcome your pull requests.
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Contributor License Agreement ("CLA")
+In order to accept your pull request, we need you to submit a CLA. You only need
+to do this once to work on any of Facebook's open source projects.
+
+Complete your CLA here: <https://code.facebook.com/cla>
+
+## Issues
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
+disclosure of security bugs. In those cases, please go through the process
+outlined on that page and do not file a public issue.
+
+## License
+By contributing to prop-types, you agree that your contributions will be licensed
+under the LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
**what is the change?:**
Even though this is a small project and we don't expect changes, it's
standard to include a `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` doc.

**why make this change?:**
Let's give folks info about how to contribute, to foster a welcoming open source community in the React ecosystem.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [prop-types Community Profile](https://github.com/facebook/prop-types/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1307" alt="screen shot 2017-11-23 at 12 15 50 pm" src="https://user-images.githubusercontent.com/1114467/33187716-a627ae5e-d048-11e7-98f3-098f6895e3b4.png">
<img width="1311" alt="screen shot 2017-11-23 at 12 16 08 pm" src="https://user-images.githubusercontent.com/1114467/33187717-a68b3280-d048-11e7-8e4e-abaeda6e1cc1.png">

**issue:**
internal task t23481323