### PR TITLE
[Add ComponentOfType]

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ class MyComponent extends React.Component {
   }
 }
 
+const OtherComponent = () => <div/>
+
 MyComponent.propTypes = {
   // You can declare that a prop is a specific JS primitive. By default, these
   // are all optional.
@@ -93,11 +95,14 @@ MyComponent.propTypes = {
   // it as an enum.
   optionalEnum: PropTypes.oneOf(['News', 'Photos']),
 
+  optionalElementWithType: PropTypes.elementWithType(['div', OtherComponent]),
+
   // An object that could be one of many types
   optionalUnion: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
-    PropTypes.instanceOf(Message)
+    PropTypes.instanceOf(Message),
+    PropTypes.elementWithType(['label'])
   ]),
 
   // An array of a certain type

--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -1044,6 +1044,100 @@ describe('PropTypesDevelopmentReact15', () => {
     });
   });
 
+  describe('ElementWithType Types', () => {
+    it('should fail for mismatched component.type', () => {
+      typeCheckFail(
+        PropTypes.elementWithType('div'),
+        <span/>,
+        "Warning: Failed prop type: Invalid prop `testProp` of type [span] supplied to `testComponent`, expected one of type `div`."
+      );
+    });
+
+    it('should pass for matched component.type', () => {
+      typeCheckPass(PropTypes.elementWithType('div'), <div />);
+    });
+
+    it('should pass if no component given', () => {
+      typeCheckPass(PropTypes.elementWithType('div'));
+    });
+
+    describe('factory error', () => {
+      it('should fail if using any value thats not a function nor a string for expectedTypes', () => {
+        spyOn(console, 'error');
+
+        PropTypes.elementWithType(1);
+
+        expect(console.error).toHaveBeenCalled();
+        expect(console.error.calls.argsFor(0)[0]).toContain(
+          "Invalid argument supplied to ElementWithType, expected an Html tag name or a Component."
+        );
+
+        typeCheckPass(PropTypes.elementWithType(1), <span />);
+      });
+    });
+
+    describe('with .isRequired', () => {
+      it('should fail if not passing in anything', () => {
+        typeCheckFail(
+          PropTypes.elementWithType('div').isRequired,
+          null,
+          "Warning: Failed prop type: The prop `testProp` is marked as required in `testComponent`, but its value is `null`."
+        );
+      });
+    });
+
+    describe('custom component', () => {
+      const MyComponent = () => <div></div>;
+      var myComponentPropType;
+      beforeEach(() => {
+        myComponentPropType = PropTypes.elementWithType(MyComponent)
+      });
+
+      it('should fail for mismatched component.type', () => {
+        typeCheckFail(
+          myComponentPropType,
+          <span />,
+          "Warning: Failed prop type: Invalid prop `testProp` of type [span] supplied to `testComponent`, expected one of type `MyComponent`."
+        );
+      });
+
+      it('should pass for matched component.type', () => {
+        typeCheckPass(myComponentPropType, <MyComponent />);
+      });
+    });
+
+    describe('given component mismatches with expected', () => {
+      it('should warn if given invalid element', () => {
+        [
+          '<div></div>',
+          { type: 'div' },
+          1,
+          ['div'],
+          'div'
+        ].forEach(invalidElement =>
+          typeCheckFail(
+            PropTypes.elementWithType('div'),
+            invalidElement,
+            "Warning: Failed prop type: Invalid prop `testProp` of component `testComponent` has been given invalid component."
+          )
+        );
+      });
+    });
+
+    describe('list of expected types', () => {
+      it('should warn if expected type does not include given component.type', () => {
+        typeCheckFail(
+          PropTypes.elementWithType('div'),
+          <span />,
+          "Warning: Failed prop type: Invalid prop `testProp` of type [span] supplied to `testComponent`, expected one of type `div`."
+        );
+      });
+      it('should pass if expected type include given component.type', () => {
+        typeCheckPass(PropTypes.elementWithType('div'), <div />)
+      });
+    });
+  });
+
   describe('Union Types', () => {
     it('should warn but not error for invalid argument', () => {
       spyOn(console, 'error');

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -1118,6 +1118,100 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
   });
 
+  describe('ElementWithType Types', () => {
+    it('should fail for mismatched component.type', () => {
+      typeCheckFail(
+        PropTypes.elementWithType('div'),
+        <span />,
+        "Warning: Failed prop type: Invalid prop `testProp` of type [span] supplied to `testComponent`, expected one of type `div`."
+      );
+    });
+
+    it('should pass for matched component.type', () => {
+      typeCheckPass(PropTypes.elementWithType('div'), <div />);
+    });
+
+    it('should pass if no component given', () => {
+      typeCheckPass(PropTypes.elementWithType('div'));
+    });
+
+    describe('factory error', () => {
+      it('should fail if using any value thats not a function nor a string for expectedTypes', () => {
+        spyOn(console, 'error');
+
+        PropTypes.elementWithType(1);
+
+        expect(console.error).toHaveBeenCalled();
+        expect(console.error.calls.argsFor(0)[0]).toContain(
+          "Invalid argument supplied to ElementWithType, expected an Html tag name or a Component."
+        );
+
+        typeCheckPass(PropTypes.elementWithType(1), <span />);
+      });
+    });
+
+    describe('with .isRequired', () => {
+      it('should fail if not passing in anything', () => {
+        typeCheckFail(
+          PropTypes.elementWithType('div').isRequired,
+          null,
+          "Warning: Failed prop type: The prop `testProp` is marked as required in `testComponent`, but its value is `null`."
+        );
+      });
+    });
+
+    describe('custom component', () => {
+      const MyComponent = () => <div></div>;
+      var myComponentPropType;
+      beforeEach(() => {
+        myComponentPropType = PropTypes.elementWithType(MyComponent)
+      });
+
+      it('should fail for mismatched component.type', () => {
+        typeCheckFail(
+          myComponentPropType,
+          <span />,
+          "Warning: Failed prop type: Invalid prop `testProp` of type [span] supplied to `testComponent`, expected one of type `MyComponent`."
+        );
+      });
+
+      it('should pass for matched component.type', () => {
+        typeCheckPass(myComponentPropType, <MyComponent />);
+      });
+    });
+
+    describe('given component mismatches with expected', () => {
+      it('should warn if given invalid element', () => {
+        [
+          '<div></div>',
+          { type: 'div' },
+          1,
+          ['div'],
+          'div'
+        ].forEach(invalidElement =>
+          typeCheckFail(
+            PropTypes.elementWithType('div'),
+            invalidElement,
+            "Warning: Failed prop type: Invalid prop `testProp` of component `testComponent` has been given invalid component."
+          )
+          );
+      });
+    });
+
+    describe('list of expected types', () => {
+      it('should warn if expected type does not include given component.type', () => {
+        typeCheckFail(
+          PropTypes.elementWithType('div'),
+          <span />,
+          "Warning: Failed prop type: Invalid prop `testProp` of type [span] supplied to `testComponent`, expected one of type `div`."
+        );
+      });
+      it('should pass if expected type include given component.type', () => {
+        typeCheckPass(PropTypes.elementWithType('div'), <div />)
+      });
+    });
+  });
+
   describe('Union Types', () => {
     it('should warn but not error for invalid argument', () => {
       spyOn(console, 'error');

--- a/__tests__/PropTypesProductionReact15-test.js
+++ b/__tests__/PropTypesProductionReact15-test.js
@@ -800,6 +800,96 @@ describe('PropTypesProductionReact15', () => {
     });
   });
 
+  describe('ElementWithType Types', () => {
+    it('should fail for mismatched component.type', () => {
+      expectNoop(
+        PropTypes.elementWithType('div'),
+        <span />,
+        "Warning: Failed prop type: Invalid prop `testProp` of type [span] supplied to `testComponent`, expected one of type `div`."
+      );
+    });
+
+    it('should pass for matched component.type', () => {
+      expectNoop(PropTypes.elementWithType('div'), <div />);
+    });
+
+    it('should pass if no component given', () => {
+      expectNoop(PropTypes.elementWithType('div'));
+    });
+
+    describe('factory error', () => {
+      it('should fail if using any value thats not a function nor a string for expectedTypes', () => {
+        spyOn(console, 'error');
+
+        PropTypes.elementWithType(1);
+
+        expect(console.error).not.toHaveBeenCalled();
+        expectNoop(PropTypes.elementWithType(1), <span />);
+      });
+    });
+
+    describe('with .isRequired', () => {
+      it('should fail if not passing in anything', () => {
+        expectNoop(
+          PropTypes.elementWithType('div').isRequired,
+          null,
+          "Warning: Failed prop type: The prop `testProp` is marked as required in `testComponent`, but its value is `null`."
+        );
+      });
+    });
+
+    describe('custom component', () => {
+      const MyComponent = () => <div></div>;
+      var myComponentPropType;
+      beforeEach(() => {
+        myComponentPropType = PropTypes.elementWithType(MyComponent)
+      });
+
+      it('should fail for mismatched component.type', () => {
+        expectNoop(
+          myComponentPropType,
+          <span />,
+          "Warning: Failed prop type: Invalid prop `testProp` of type [span] supplied to `testComponent`, expected one of type `MyComponent`."
+        );
+      });
+
+      it('should pass for matched component.type', () => {
+        expectNoop(myComponentPropType, <MyComponent />);
+      });
+    });
+
+    describe('given component mismatches with expected', () => {
+      it('should warn if given invalid element', () => {
+        [
+          '<div></div>',
+          { type: 'div' },
+          1,
+          ['div'],
+          'div'
+        ].forEach(invalidElement =>
+          expectNoop(
+            PropTypes.elementWithType('div'),
+            invalidElement,
+            "Warning: Failed prop type: Invalid prop `testProp` of component `testComponent` has been given invalid component."
+          )
+          );
+      });
+    });
+
+    describe('list of expected types', () => {
+      it('should warn if expected type does not include given component.type', () => {
+        expectNoop(
+          PropTypes.elementWithType('div'),
+          <span />,
+          "Warning: Failed prop type: Invalid prop `testProp` of type [span] supplied to `testComponent`, expected one of type `div`."
+        );
+      });
+      it('should pass if expected type include given component.type', () => {
+        expectNoop(PropTypes.elementWithType('div'), <div />)
+      });
+    });
+  });
+
   describe('Union Types', () => {
     it('should ignore invalid argument', () => {
       spyOn(console, 'error');

--- a/__tests__/PropTypesProductionStandalone-test.js
+++ b/__tests__/PropTypesProductionStandalone-test.js
@@ -194,6 +194,16 @@ describe('PropTypesProductionStandalone', function() {
     });
   });
 
+  describe('elementWithType Types', () => {
+    it('should be a no-op', () => {
+      expectThrowsInProduction(PropTypes.elementWithType(1));
+      expectThrowsInProduction(PropTypes.elementWithType('div'), 'div');
+      expectThrowsInProduction(PropTypes.elementWithType('div'), { type: 'div' });
+      expectThrowsInProduction(PropTypes.elementWithType(['div', 'span']), <div/>);
+      expectThrowsInProduction(PropTypes.elementWithType('div'), [<div/>, <span/>]);
+    });
+  });
+
   describe('Union Types', function() {
     it('should be a no-op', function() {
       expectThrowsInProduction(

--- a/factoryWithThrowingShims.js
+++ b/factoryWithThrowingShims.js
@@ -51,6 +51,7 @@ module.exports = function() {
     objectOf: getShim,
     oneOf: getShim,
     oneOfType: getShim,
+    elementWithType: getShim,
     shape: getShim,
     exact: getShim,
 

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -374,7 +374,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       return emptyFunction.thatReturnsNull;
     }
 
-    function getDisplayName (comp) {
+    function getDisplayName(comp) {
       return typeof comp === 'function' ? comp.displayName || comp.name : comp;
     }
 

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -381,7 +381,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
     function validate(props, propName, componentName, location, propFullName) {
       var propValues = [].concat(props[propName]);
 
-      if (propValues.some(pv => !isValidElement(pv))) {
+      if (propValues.some(function (pv) { return !isValidElement(pv); })) {
         return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of component `' + componentName + '` has been given invalid component.');
       }
 

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -387,7 +387,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
 
       var hasInvalid = propValues.some(propValue => expectedType !== propValue.type);
       if (hasInvalid) {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type [' + propValues.map(pv => pv.type).map(getDisplayName).join(', ') + '] ' + ('supplied to `' + componentName + '`, expected one of type `' + getDisplayName(expectedType) + '`.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type [' + propValues.map(function (pv) return getDisplayName(pv.type)).join(', ') + '] ' + ('supplied to `' + componentName + '`, expected one of type `' + getDisplayName(expectedType) + '`.'));
       }
 
       return null;

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -369,7 +369,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
   function createElementWithTypeChecker(expectedType) {
     var ACCEPTABLE_TYPES_OF_EXPECTED_TYPES = ['string', 'function'];
 
-    if (!isValidElementType(expectedType)) {
+    if (!ReactIs.isValidElementType(expectedType)) {
       process.env.NODE_ENV !== 'production' ? warning(false, 'Invalid argument supplied to ElementWithType, expected an Html tag name or a Component.') : void 0;
       return emptyFunction.thatReturnsNull;
     }
@@ -385,9 +385,11 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
         return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of component `' + componentName + '` has been given invalid component.');
       }
 
-      var hasInvalid = propValues.some(propValue => expectedType !== propValue.type);
+      var hasInvalid = propValues.some(function(propValue) {
+        return expectedType !== propValue.type
+      });
       if (hasInvalid) {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type [' + propValues.map(function (pv) return getDisplayName(pv.type)).join(', ') + '] ' + ('supplied to `' + componentName + '`, expected one of type `' + getDisplayName(expectedType) + '`.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type [' + propValues.map(function (pv) { return getDisplayName(pv.type) }).join(', ') + '] ' + ('supplied to `' + componentName + '`, expected one of type `' + getDisplayName(expectedType) + '`.'));
       }
 
       return null;

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -369,7 +369,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
   function createElementWithTypeChecker(expectedType) {
     var ACCEPTABLE_TYPES_OF_EXPECTED_TYPES = ['string', 'function'];
 
-    if (ACCEPTABLE_TYPES_OF_EXPECTED_TYPES.indexOf(typeof expectedType) === -1) {
+    if (!isValidElementType(expectedType)) {
       process.env.NODE_ENV !== 'production' ? warning(false, 'Invalid argument supplied to ElementWithType, expected an Html tag name or a Component.') : void 0;
       return emptyFunction.thatReturnsNull;
     }


### PR DESCRIPTION
Adds `ComponentOfType` propType checker.

This helps check Component's type on the receiving end.
```js 
//  1. single expected
  propType = {
    label: elementOfType('label')
  }

// 2. multiple expected, multiple given
  propType = {
    children: elementOfType([ MyListItem, 'label' ])
  }

  propType = {
    children: elementOfType([ ...SVG_TAG_GROUP, MyCustomTag ])
  }
```