### PR TITLE
Fix type hinting for IDE for isRequired

### DIFF
--- a/factoryWithThrowingShims.js
+++ b/factoryWithThrowingShims.js
@@ -28,6 +28,8 @@ module.exports = function() {
   function getShim() {
     return shim;
   };
+  getShim.isRequired = shim;
+  
   // Important!
   // Keep this list in sync with production version in `./factoryWithTypeCheckers.js`.
   var ReactPropTypes = {


### PR DESCRIPTION
isRequired is currently unrecognised by IDEs when using `arrayOf`, `shape` and others. This will fix the type-hinting for it.

See:

![image](https://user-images.githubusercontent.com/4533329/36843344-5142ebd6-1d57-11e8-9dd2-539a846cf02b.png)