### PR TITLE
Update README to include .exact()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ var PropTypes = require('prop-types'); // ES5 with npm
 
 ### CDN
 
-If you prefer to exclude `prop-types` from your application and use it 
-globally via `window.PropTypes`, the `prop-types` package provides 
+If you prefer to exclude `prop-types` from your application and use it
+globally via `window.PropTypes`, the `prop-types` package provides
 single-file distributions, which are hosted on the following CDNs:
 
 * [**unpkg**](https://unpkg.com/prop-types/)
@@ -44,7 +44,7 @@ single-file distributions, which are hosted on the following CDNs:
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.6.0/prop-types.min.js"></script>
 ```
 
-To load a specific version of `prop-types` replace `15.6.0` with the version number. 
+To load a specific version of `prop-types` replace `15.6.0` with the version number.
 
 ## Usage
 
@@ -167,7 +167,7 @@ For example:
 
 ```js
   "dependencies": {
-    "prop-types": "^15.5.7" 
+    "prop-types": "^15.5.7"
   }
 ```
 
@@ -175,10 +175,10 @@ For libraries, we *also* recommend leaving it in `dependencies`:
 
 ```js
   "dependencies": {
-    "prop-types": "^15.5.7" 
+    "prop-types": "^15.5.7"
   },
   "peerDependencies": {
-    "react": "^15.5.0" 
+    "react": "^15.5.0"
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ MyComponent.propTypes = {
 
   // An object with warnings on extra properties
   optionalObjectWithStrictShape: PropTypes.exact({
-    color: PropTypes.string,
-    fontSize: PropTypes.number
+    optionalProperty: PropTypes.string,
+    requiredProperty: PropTypes.number.isRequired
   }),
 
   // You can chain any of the above with `isRequired` to make sure a warning

--- a/README.md
+++ b/README.md
@@ -102,10 +102,13 @@ MyComponent.propTypes = {
   // An object with property values of a certain type
   optionalObjectOf: PropTypes.objectOf(PropTypes.number),
 
+  // You can chain any of the above with `isRequired` to make sure a warning
+  // is shown if the prop isn't provided.
+
   // An object taking on a particular shape
   optionalObjectWithShape: PropTypes.shape({
-    color: PropTypes.string,
-    fontSize: PropTypes.number
+    optionalProperty: PropTypes.string,
+    requiredProperty: PropTypes.number.isRequired
   }),
 
   // An object with warnings on extra properties
@@ -114,8 +117,6 @@ MyComponent.propTypes = {
     requiredProperty: PropTypes.number.isRequired
   }),
 
-  // You can chain any of the above with `isRequired` to make sure a warning
-  // is shown if the prop isn't provided.
   requiredFunc: PropTypes.func.isRequired,
 
   // A value of any data type

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ MyComponent.propTypes = {
     fontSize: PropTypes.number
   }),
 
+  // An object with warnings on extra properties
+  optionalObjectWithStrictShape: PropTypes.exact({
+    color: PropTypes.string,
+    fontSize: PropTypes.number
+  }),
+
   // You can chain any of the above with `isRequired` to make sure a warning
   // is shown if the prop isn't provided.
   requiredFunc: PropTypes.func.isRequired,


### PR DESCRIPTION
Let’s include `.exact` in the README! 🎉

Also shows that one can use `isRequired` on individual properties inside ´shape´ and ´exact´ and removes trailing spaces.

Thanks for maintaining this awesome project and a love letter 💌 to @gaearon! His documentation made me look up the typographic apostrophe ( ’ )!