### PR TITLE
Support validation when hasOwnProperty is not in prototype

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -777,8 +777,18 @@ describe('PropTypesDevelopmentReact15', () => {
       );
     });
 
+    it('should not warn when passing an object with no prototype', () => {
+      typeCheckPass(PropTypes.objectOf(PropTypes.number), Object.create(null));
+    });
+
     it('should not warn when passing an empty object', () => {
       typeCheckPass(PropTypes.objectOf(PropTypes.number), {});
+    });
+
+    it('should not warn when passing an object with a hasOwnProperty property', () => {
+      typeCheckPass(PropTypes.objectOf(PropTypes.number), {
+        hasOwnProperty: 3,
+      });
     });
 
     it('should be implicitly optional and not warn without values', () => {

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -779,8 +779,18 @@ describe('PropTypesDevelopmentStandalone', () => {
       );
     });
 
+    it('should not warn when passing an object with no prototype', () => {
+      typeCheckPass(PropTypes.objectOf(PropTypes.number), Object.create(null));
+    });
+
     it('should not warn when passing an empty object', () => {
       typeCheckPass(PropTypes.objectOf(PropTypes.number), {});
+    });
+
+    it('should not warn when passing an object with a hasOwnProperty property', () => {
+      typeCheckPass(PropTypes.objectOf(PropTypes.number), {
+        hasOwnProperty: 3,
+      });
     });
 
     it('should be implicitly optional and not warn without values', () => {

--- a/__tests__/PropTypesProductionReact15-test.js
+++ b/__tests__/PropTypesProductionReact15-test.js
@@ -649,8 +649,18 @@ describe('PropTypesProductionReact15', () => {
       );
     });
 
+    it('should not warn when passing an object with no prototype', () => {
+      expectNoop(PropTypes.objectOf(PropTypes.number), Object.create(null));
+    });
+
     it('should not warn when passing an empty object', () => {
       expectNoop(PropTypes.objectOf(PropTypes.number), {});
+    });
+
+    it('should not warn when passing an object with a hasOwnProperty property', () => {
+      expectNoop(PropTypes.objectOf(PropTypes.number), {
+        hasOwnProperty: 3,
+      });
     });
 
     it('should be implicitly optional and not warn without values', () => {

--- a/checkPropTypes.js
+++ b/checkPropTypes.js
@@ -12,6 +12,7 @@ var printWarning = function() {};
 if (process.env.NODE_ENV !== 'production') {
   var ReactPropTypesSecret = require('./lib/ReactPropTypesSecret');
   var loggedTypeFailures = {};
+  var has = Function.call.bind(Object.prototype.hasOwnProperty);
 
   printWarning = function(text) {
     var message = 'Warning: ' + text;
@@ -41,7 +42,7 @@ if (process.env.NODE_ENV !== 'production') {
 function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
   if (process.env.NODE_ENV !== 'production') {
     for (var typeSpecName in typeSpecs) {
-      if (typeSpecs.hasOwnProperty(typeSpecName)) {
+      if (has(typeSpecs, typeSpecName)) {
         var error;
         // Prop type validation may throw. In case they do, we don't want to
         // fail the render phase where it didn't fail before. So we log it.


### PR DESCRIPTION
Avoids the `Warning: Failed prop type: propValue.hasOwnProperty is not a function` warning when `hasOwnProperty` is not defined in the prototype chain.

See #183 for details.

---

- On the original issue @ljharb [noted something about `delete Object.prototype.hasOwnProperty` being a thing](https://github.com/facebook/prop-types/issues/183#issuecomment-390845818). I did not quite get this comment, so this solution might not work because of that. Just close this PR in that case.
- I did not add tests for the combined case of `PropTypes.shape({ q: PropTypes.objectOf(PropTypes.string) })` I pointed out in https://github.com/facebook/prop-types/issues/183#issuecomment-392545102, as I didn't know where to place them
