### PR TITLE
Add expected types to oneOfType warning

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -1080,7 +1080,7 @@ describe('PropTypesDevelopmentReact15', () => {
       typeCheckFail(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         [],
-        'Invalid prop `testProp` supplied to `testComponent`.',
+        'Invalid prop `testProp` supplied to `testComponent`, expected one of type [string, number].',
       );
 
       const checker = PropTypes.oneOfType([

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -1154,7 +1154,7 @@ describe('PropTypesDevelopmentStandalone', () => {
       typeCheckFail(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         [],
-        'Invalid prop `testProp` supplied to `testComponent`.',
+        'Invalid prop `testProp` supplied to `testComponent`, expected one of type [string, number].',
       );
 
       const checker = PropTypes.oneOfType([


### PR DESCRIPTION
Adds data object to returned error in type checker so that the expected types can be accessed from within oneOfType check. Also, updates the tests slightly.

Fixes #9. Fixes https://github.com/facebook/react/issues/1919.