### PR TITLE
Completely remove envify in favor of loose-envify

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,12 @@
   },
   "homepage": "https://facebook.github.io/react/",
   "dependencies": {
-    "loose-envify": "^1.3.1",
     "object-assign": "^4.1.1"
   },
   "scripts": {
     "test": "jest",
-    "umd": "NODE_ENV=development browserify index.js -t envify --standalone PropTypes -o prop-types.js",
-    "umd-min": "NODE_ENV=production browserify index.js -t envify -t uglifyify --standalone PropTypes  -p bundle-collapser/plugin -o | uglifyjs --compress unused,dead_code -o prop-types.min.js",
+    "umd": "NODE_ENV=development browserify index.js -t loose-envify --standalone PropTypes -o prop-types.js",
+    "umd-min": "NODE_ENV=production browserify index.js -t loose-envify -t uglifyify --standalone PropTypes  -p bundle-collapser/plugin -o | uglifyjs --compress unused,dead_code -o prop-types.min.js",
     "build": "yarn umd && yarn umd-min",
     "prepublish": "yarn build"
   },
@@ -40,8 +39,8 @@
     "babel-preset-react": "^6.24.1",
     "browserify": "^14.3.0",
     "bundle-collapser": "^1.2.1",
-    "envify": "^4.0.0",
     "jest": "^19.0.2",
+    "loose-envify": "^1.3.1",
     "react": "^15.5.1",
     "uglifyify": "^3.0.4",
     "uglifyjs": "^2.4.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,13 +956,6 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-envify@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/envify/-/envify-4.1.0.tgz#f39ad3db9d6801b4e6b478b61028d3f0b6819f7e"
-  dependencies:
-    esprima "^4.0.0"
-    through "~2.3.4"
-
 errno@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"


### PR DESCRIPTION
Following the discussion in #203, this PR move `loose-envify` from dependencies to devDependencies. 

I also took the opportunity to choose `loose-envify` over `envify` everywhere, as they are doing the same thing anyway. I have no opinion whether `loose-envify` is better than `envify` or not. Using `yarn run test` does not show any measurable difference in term of execution time, so I can switch back to `envify` if you prefer.

Closes #203.