### PR TITLE
Add a PropTypes for React elementType (ie. MyComponent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,11 @@ MyComponent.propTypes = {
   // (or fragment) containing these types.
   optionalNode: PropTypes.node,
 
-  // A React element.
+  // A React element (ie. <MyComponent />).
   optionalElement: PropTypes.element,
+
+  // A React element type (ie. MyComponent).
+  optionalElementType: PropTypes.elementType,
 
   // You can also declare that a prop is an instance of a class. This uses
   // JS's instanceof operator.

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -18,6 +18,7 @@ function resetWarningCache() {
   React = require('react');
   PropTypes = require('../index');
 }
+resetWarningCache();
 
 function getPropTypeWarningMessage(propTypes, object, componentName) {
   if (!console.error.calls) {
@@ -552,6 +553,77 @@ describe('PropTypesDevelopmentStandalone', () => {
       expectThrowsInDevelopment(PropTypes.element, false);
       expectThrowsInDevelopment(PropTypes.element.isRequired, null);
       expectThrowsInDevelopment(PropTypes.element.isRequired, undefined);
+    });
+  });
+
+  describe('ElementType Types', () => {
+    it('should support native component', () => {
+      typeCheckPass(PropTypes.elementType, 'div');
+    });
+
+    it('should support stateless component', () => {
+      var MyComponent = () => <div />;
+      typeCheckPass(PropTypes.elementType, MyComponent);
+    });
+
+    it('should support stateful component', () => {
+      class MyComponent extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      typeCheckPass(PropTypes.elementType, MyComponent);
+    });
+
+    (React.forwardRef ? it : it.skip)('should support forwardRef component', () => {
+      const MyForwardRef = React.forwardRef((props, ref) => <div ref={ref} />);
+      typeCheckPass(PropTypes.elementType, MyForwardRef);
+    });
+
+    (React.createContext ? it : it.skip)('should support context provider component', () => {
+      const MyContext = React.createContext('test');
+      typeCheckPass(PropTypes.elementType, MyContext.Provider);
+    });
+
+    (React.createContext ? it : it.skip)('should support context consumer component', () => {
+      const MyContext = React.createContext('test');
+      typeCheckPass(PropTypes.elementType, MyContext.Consumer);
+    });
+
+    it('should warn for invalid types', () => {
+      typeCheckFail(
+        PropTypes.elementType,
+        true,
+        'Invalid prop `testProp` of type `boolean` supplied to ' +
+          '`testComponent`, expected a single ReactElement type.',
+      );
+
+      typeCheckFail(
+        PropTypes.elementType,
+        {},
+        'Invalid prop `testProp` of type `object` supplied to ' +
+          '`testComponent`, expected a single ReactElement type.',
+      );
+
+      typeCheckFail(
+        PropTypes.elementType,
+        [],
+        'Invalid prop `testProp` of type `array` supplied to ' +
+          '`testComponent`, expected a single ReactElement type.',
+      );
+
+      it('should warn for missing required values', () => {
+        typeCheckFailRequiredValues(PropTypes.elementType.isRequired);
+      });
+    });
+
+    it('should warn for React element', () => {
+      typeCheckFail(
+        PropTypes.elementType,
+        <div />,
+        'Invalid prop `testProp` of type `object` supplied to ' +
+          '`testComponent`, expected a single ReactElement type.',
+      );
     });
   });
 

--- a/__tests__/PropTypesProductionStandalone-test.js
+++ b/__tests__/PropTypesProductionStandalone-test.js
@@ -162,6 +162,13 @@ describe('PropTypesProductionStandalone', function() {
     });
   });
 
+  describe('React ElementType Type', function() {
+    it('shoud be a no-op', function() {
+      expectThrowsInProduction(PropTypes.elementType.isRequired, false);
+      expectThrowsInProduction(PropTypes.elementType.isRequired, {});
+    });
+  });
+
   describe('ObjectOf Type', function() {
     it('should be a no-op', function() {
       expectThrowsInProduction(PropTypes.objectOf({foo: PropTypes.string}), {

--- a/factoryWithThrowingShims.js
+++ b/factoryWithThrowingShims.js
@@ -45,6 +45,7 @@ module.exports = function() {
     any: shim,
     arrayOf: getShim,
     element: shim,
+    elementType: shim,
     instanceOf: getShim,
     node: shim,
     objectOf: getShim,

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+var ReactIs = require('react-is');
 var assign = require('object-assign');
 
 var ReactPropTypesSecret = require('./lib/ReactPropTypesSecret');
@@ -123,6 +124,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
     any: createAnyTypeChecker(),
     arrayOf: createArrayOfTypeChecker,
     element: createElementTypeChecker(),
+    elementType: createElementTypeTypeChecker(),
     instanceOf: createInstanceTypeChecker,
     node: createNodeChecker(),
     objectOf: createObjectOfTypeChecker,
@@ -270,6 +272,18 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       if (!isValidElement(propValue)) {
         var propType = getPropType(propValue);
         return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement.'));
+      }
+      return null;
+    }
+    return createChainableTypeChecker(validate);
+  }
+
+  function createElementTypeTypeChecker() {
+    function validate(props, propName, componentName, location, propFullName) {
+      var propValue = props[propName];
+      if (!ReactIs.isValidElementType(propValue)) {
+        var propType = getPropType(propValue);
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement type.'));
       }
       return null;
     }

--- a/index.js
+++ b/index.js
@@ -6,21 +6,12 @@
  */
 
 if (process.env.NODE_ENV !== 'production') {
-  var REACT_ELEMENT_TYPE = (typeof Symbol === 'function' &&
-    Symbol.for &&
-    Symbol.for('react.element')) ||
-    0xeac7;
-
-  var isValidElement = function(object) {
-    return typeof object === 'object' &&
-      object !== null &&
-      object.$$typeof === REACT_ELEMENT_TYPE;
-  };
+  var ReactIs = require('react-is');
 
   // By explicitly using `prop-types` you are opting into new development behavior.
   // http://fb.me/prop-types-in-prod
   var throwOnDirectAccess = true;
-  module.exports = require('./factoryWithTypeCheckers')(isValidElement, throwOnDirectAccess);
+  module.exports = require('./factoryWithTypeCheckers')(ReactIs.isElement, throwOnDirectAccess);
 } else {
   // By explicitly using `prop-types` you are opting into new production behavior.
   // http://fb.me/prop-types-in-prod

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://facebook.github.io/react/",
   "dependencies": {
-    "object-assign": "^4.1.1"
+    "object-assign": "^4.1.1",
+    "react-is": "^16.8.1"
   },
   "scripts": {
     "test": "jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,6 +2356,11 @@ randombytes@^2.0.0, randombytes@^2.0.1:
   dependencies:
     safe-buffer "^5.1.0"
 
+react-is@^16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.1.tgz#a80141e246eb894824fb4f2901c0c50ef31d4cdb"
+  integrity sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA==
+
 react@^15.5.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"


### PR DESCRIPTION
There is a missing prop type that is quite common for a lot of people: `PropTypes.component`. The `PropTypes.element` already exists to support `<MyComponent myProp={<MyOtherComponent />} />`. However, there is no way to easily type check: `<MyComponent myProp={MyOtherComponent} />`. Before React 16.3, we were getting away with `PropTypes.func`. 

# ForwardRef in 16.3
However, with new features since React 16.3, there is a new challenge: forward ref! `forwardRef` is generating a React component, but in a different form: it is an object! This is breaking the old way of using the `PropTypes.func` and making the type checking unreliable. To fix this, we need a more complex prop type:

```
MyComponent.propTypes = {
  myProp: PropTypes.oneOf([
    PropTypes.func,
    PropTypes.shape({
      $$typeof: PropTypes.symbol
    })
  ]).isRequired
};
```

The problem with this:
1. Now we're leaking an internal implementation of React
1. If you pass an element (`<MyComponent />`) instead of a component (`MyComponent`), it would not fail. An addition check on the $$typeof value has to be made and now the complexity is getting out of hand for a prop type that should be simple.

To fix this, I've added `PropTypes.component` that would fix this problem by checking the `$$typeof` and only allow components.

# Higher-Order Component (HOC)
The reason why this prop type is so important to add is because of HOC. If you're using a library HOC, as soon as you add the decorator on your component using `forwardRef` (example react-cookie, see https://github.com/reactivestack/cookies/issues/172), your component is an object instead of a function and most libraries (example react-router) are using `PropTypes.func` to check if your passing a component. The typecheck wrongfully fails.

# What should be a component?
First we need to support regular stateless and stateful component. The best way to do that is by checking if it's a function. I don't think we can do better here unfortunately because of stateless components.

Then, there is special cases created by React like the forward ref. Here are all the `$$typeof` we can check and which one should be a component or not:

- REACT_PROVIDER_TYPE: Yes
- REACT_CONTEXT_TYPE: Yes
- REACT_FORWARD_REF_TYPE: Yes

- REACT_ELEMENT_TYPE: No
- REACT_PORTAL_TYPE: No
- REACT_FRAGMENT_TYPE: No
- REACT_STRICT_MODE_TYPE: No
- REACT_PROFILER_TYPE: No
- REACT_ASYNC_MODE_TYPE: No
- REACT_PLACEHOLDER_TYPE`: No

Forward ref is the most obvious use-case, but the context provider/consumer are technically component created by React. I just don't think it would be used much in a prop though.

# Remaining Concerns
Here are my main concerns with this PR:

## Bumping React version to 16 in devDependencies
The tests were running on the old 15 version of React, I'm guessing to make sure we don't break the old version. However, to test forward ref and the context API, we need at least React 16.3. I've updated the version, but an alternative would be to have two different package with the different version. Is it worth it? Also, should we bump the version of prop-types to 16? There is no breaking change, but the tests would be running on that version unless we run the tests on both by adding a proxy package pointing to React 15.

## Should we really call that new prop type component?
I think it's the best name, but in the previous code, the prop type element (and sometimes node) were referred as component. To me, a React component is `MyComponent` while a React element is `<MyComponent />`. Is it so for the community? Is the distinction clear enough?

**EDIT**: Been renamed `elementType` to follow `is-react` name.

## Where I've added `isValidComponent`
Looking at the `isValidElement` code, I tried to stay consistent with where to put the code. However, I'm not sure this is 100% clean. I can refactor this if you think this is a problem, but I've tried to stay consistent with the current state of the code.

## Should we have more validation?
We could add more validation. Is the component should be a specific one? Should the component have a specific set of prop type (not sure about the use cases)?

## Documentation
If this is merged, we would need to update the React documentation with the new prop type. I can help with that once this is merged.

Fixes #223.