### PR TITLE
Fix oneOf when used with Symbols

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -929,6 +929,12 @@ describe('PropTypesDevelopmentReact15', () => {
         'Invalid prop `testProp` of value `false` supplied to ' +
           '`testComponent`, expected one of [0,"false"].',
       );
+      typeCheckFail(
+        PropTypes.oneOf([Symbol('red'), Symbol('blue')]),
+        Symbol('green'),
+        'Invalid prop `testProp` of value `Symbol(green)` supplied to ' +
+          '`testComponent`, expected one of ["Symbol(red)","Symbol(blue)"].',
+      );
     });
 
     it('should not warn for valid values', () => {

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -931,6 +931,12 @@ describe('PropTypesDevelopmentStandalone', () => {
         'Invalid prop `testProp` of value `false` supplied to ' +
           '`testComponent`, expected one of [0,"false"].',
       );
+      typeCheckFail(
+        PropTypes.oneOf([Symbol('red'), Symbol('blue')]),
+        Symbol('green'),
+        'Invalid prop `testProp` of value `Symbol(green)` supplied to ' +
+          '`testComponent`, expected one of ["Symbol(red)","Symbol(blue)"].',
+      );
     });
 
     it('should not warn for valid values', () => {

--- a/__tests__/PropTypesProductionReact15-test.js
+++ b/__tests__/PropTypesProductionReact15-test.js
@@ -728,6 +728,12 @@ describe('PropTypesProductionReact15', () => {
         'Invalid prop `testProp` of value `false` supplied to ' +
           '`testComponent`, expected one of [0,"false"].',
       );
+      expectNoop(
+        PropTypes.oneOf([Symbol('red'), Symbol('blue')]),
+        Symbol('green'),
+        'Invalid prop `testProp` of value `Symbol(green)` supplied to ' +
+          '`testComponent`, expected one of ["Symbol(red)","Symbol(blue)"].',
+      );
     });
 
     it('should not warn for valid values', () => {

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -302,8 +302,13 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
         }
       }
 
-      var valuesString = JSON.stringify(expectedValues);
-      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + propValue + '` ' + ('supplied to `' + componentName + '`, expected one of ' + valuesString + '.'));
+      var valuesString = JSON.stringify(expectedValues, function replacer(key, value) {
+        if (getPropType(value) === 'symbol') {
+          return String(value);
+        }
+        return value;
+      });
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + String(propValue) + '` ' + ('supplied to `' + componentName + '`, expected one of ' + valuesString + '.'));
     }
     return createChainableTypeChecker(validate);
   }


### PR DESCRIPTION
- Fixes error due to an attempt to coerce a Symbol to a string
- Improves formatting of the "expected" portion of the generated warning, outputting for example `["Symbol(A)","Symbol(B)"]` rather than `[null,null]`

Fixes #10