### PR TITLE
Remove dependency on object-assign

### DIFF
--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-var assign = require('object-assign');
+var assign = Object.assign;
 
 var ReactPropTypesSecret = require('./lib/ReactPropTypesSecret');
 var checkPropTypes = require('./checkPropTypes');

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "homepage": "https://facebook.github.io/react/",
   "dependencies": {
-    "loose-envify": "^1.3.1",
-    "object-assign": "^4.1.1"
+    "loose-envify": "^1.3.1"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
As the code gets processed anyways, the dependency on a polyfill such as `object-assign` is not necessary. I replaced said dependency with an assignment to the native `Object.assign` method, so that the code works exactly like before but with one less dependency.