### PR TITLE
Fix silently failing invalid validators in shape

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -105,6 +105,15 @@ function expectWarningInDevelopment(declaration, value) {
   console.error.calls.reset();
 }
 
+function expectInvalidValidatorWarning(declaration, type) {
+  PropTypes.checkPropTypes({ foo: declaration }, { foo: {} }, 'prop', 'testComponent', null);
+  expect(console.error.calls.argsFor(0)[0]).toEqual(
+    'Warning: Failed prop type: testComponent: prop type `foo.bar` is invalid; '
+    + 'it must be a function, usually from the `prop-types` package, but received `' + type + '`.'
+  );
+  console.error.calls.reset();
+}
+
 describe('PropTypesDevelopmentReact15', () => {
   beforeEach(() => {
     resetWarningCache();
@@ -223,6 +232,22 @@ describe('PropTypesDevelopmentReact15', () => {
         + 'it must be a function, usually from the `prop-types` package, but received `undefined`.'
       );
       expect(returnValue).toBe(undefined);
+    });
+
+    it('should warn for invalid validators inside shape', () => {
+      spyOn(console, 'error');
+      expectInvalidValidatorWarning(PropTypes.shape({ bar: PropTypes.invalid_type }), 'undefined');
+      expectInvalidValidatorWarning(PropTypes.shape({ bar: true }), 'boolean');
+      expectInvalidValidatorWarning(PropTypes.shape({ bar: 'true' }), 'string');
+      expectInvalidValidatorWarning(PropTypes.shape({ bar: null }), 'null');
+    });
+
+    it('should warn for invalid validators inside exact', () => {
+      spyOn(console, 'error');
+      expectInvalidValidatorWarning(PropTypes.exact({ bar: PropTypes.invalid_type }), 'undefined');
+      expectInvalidValidatorWarning(PropTypes.exact({ bar: true }), 'boolean');
+      expectInvalidValidatorWarning(PropTypes.exact({ bar: 'true' }), 'string');
+      expectInvalidValidatorWarning(PropTypes.exact({ bar: null }), 'null');
     });
   });
 

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -102,6 +102,15 @@ function expectThrowsInDevelopment(declaration, value) {
   );
 }
 
+function expectInvalidValidatorWarning(declaration, type) {
+  PropTypes.checkPropTypes({ foo: declaration }, { foo: {} }, 'prop', 'testComponent', null);
+  expect(console.error.calls.argsFor(0)[0]).toEqual(
+    'Warning: Failed prop type: testComponent: prop type `foo.bar` is invalid; '
+    + 'it must be a function, usually from the `prop-types` package, but received `' + type + '`.'
+  );
+  console.error.calls.reset();
+}
+
 describe('PropTypesDevelopmentStandalone', () => {
   beforeEach(() => {
     resetWarningCache();
@@ -220,6 +229,22 @@ describe('PropTypesDevelopmentStandalone', () => {
         + 'it must be a function, usually from the `prop-types` package, but received `undefined`.'
       );
       expect(returnValue).toBe(undefined);
+    });
+
+    it('should warn for invalid validators inside shape', () => {
+      spyOn(console, 'error');
+      expectInvalidValidatorWarning(PropTypes.shape({ bar: PropTypes.invalid_type }), 'undefined');
+      expectInvalidValidatorWarning(PropTypes.shape({ bar: true }), 'boolean');
+      expectInvalidValidatorWarning(PropTypes.shape({ bar: 'true' }), 'string');
+      expectInvalidValidatorWarning(PropTypes.shape({ bar: null }), 'null');
+    });
+
+    it('should warn for invalid validators inside exact', () => {
+      spyOn(console, 'error');
+      expectInvalidValidatorWarning(PropTypes.exact({ bar: PropTypes.invalid_type }), 'undefined');
+      expectInvalidValidatorWarning(PropTypes.exact({ bar: true }), 'boolean');
+      expectInvalidValidatorWarning(PropTypes.exact({ bar: 'true' }), 'string');
+      expectInvalidValidatorWarning(PropTypes.exact({ bar: null }), 'null');
     });
   });
 


### PR DESCRIPTION
Fixes #220 
Possibly also #181 

This PR adds type checks for validators in `createShapeTypeChecker` and `createStrictShapeTypeChecker` so that they can fail loudly on invalid validators and everyone can be safe and happy! 😊

As outlined in #220 , providing any falsy value instead of a validator will cause validation to be skipped, meaning invalid props won't be caught. Providing a truthy value that's not a function results in a caught but displayed javascript error `Warning: Failed prop type: checker is not a function` which is better than nothing but not really that helpful.

The most likely cause of issues is typos in validator names, like `PropTypes.boolean` (which I've since discovered that I've written several times). As mentioned in #220 this is mitigated by using `eslint-plugin-react/no-typos`, but I do feel that relying on a third party that's not a dependency is more of a band-aid than a solution.

Another cause would be references to internal or external things that might or might not be functions, which is not caught by the eslint plugin.
```js
const validator = false;
Component.propTypes = {
  foo: PropTypes.shape({ bar: validator })
};
```
