### PR TITLE
Warn when multiple arguments were supplied to oneOf

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -894,11 +894,25 @@ describe('PropTypesDevelopmentReact15', () => {
     it('should warn but not error for invalid argument', () => {
       spyOn(console, 'error');
 
+      PropTypes.oneOf('red');
+
+      expect(console.error).toHaveBeenCalled();
+      expect(console.error.calls.argsFor(0)[0]).toContain(
+        'Invalid argument supplied to oneOf, expected an array.',
+      );
+
+      typeCheckPass(PropTypes.oneOf('red', 'blue'), 'red');
+    });
+
+    it('should warn but not error for invalid multiple arguments', () => {
+      spyOn(console, 'error');
+
       PropTypes.oneOf('red', 'blue');
 
       expect(console.error).toHaveBeenCalled();
       expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Invalid argument supplied to oneOf, expected an instance of array.',
+        'Invalid arguments supplied to oneOf, expected an array, got 2 arguments. '
+        + 'A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).',
       );
 
       typeCheckPass(PropTypes.oneOf('red', 'blue'), 'red');

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -896,11 +896,25 @@ describe('PropTypesDevelopmentStandalone', () => {
     it('should warn but not error for invalid argument', () => {
       spyOn(console, 'error');
 
+      PropTypes.oneOf('red');
+
+      expect(console.error).toHaveBeenCalled();
+      expect(console.error.calls.argsFor(0)[0]).toContain(
+        'Invalid argument supplied to oneOf, expected an array.',
+      );
+
+      typeCheckPass(PropTypes.oneOf('red'), 'red');
+    });
+
+    it('should warn but not error for invalid multiple arguments', () => {
+      spyOn(console, 'error');
+
       PropTypes.oneOf('red', 'blue');
 
       expect(console.error).toHaveBeenCalled();
       expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Invalid argument supplied to oneOf, expected an instance of array.',
+        'Invalid arguments supplied to oneOf, expected an array, got 2 arguments. '
+        + 'A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).',
       );
 
       typeCheckPass(PropTypes.oneOf('red', 'blue'), 'red');

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -290,7 +290,16 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
 
   function createEnumTypeChecker(expectedValues) {
     if (!Array.isArray(expectedValues)) {
-      process.env.NODE_ENV !== 'production' ? printWarning('Invalid argument supplied to oneOf, expected an instance of array.') : void 0;
+      if (process.env.NODE_ENV !== 'production') {
+        if (arguments.length > 1) {
+          printWarning(
+            `Invalid arguments supplied to oneOf, expected an array, got ${arguments.length} arguments. ` +
+            `A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).`
+          );
+        } else {
+          printWarning('Invalid argument supplied to oneOf, expected an array.');
+        }
+      }
       return emptyFunctionThatReturnsNull;
     }
 


### PR DESCRIPTION
Adds a different warning message for multiple arguments supplied to oneOf. A common mistake is to write `oneOf(x, y, z)` instead of `oneOf([x, y, z])` and this should help developers identifying the error.