### PR TITLE
Output warnings using console.warn

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -21,20 +21,20 @@ function resetWarningCache() {
 }
 
 function getPropTypeWarningMessage(propTypes, object, componentName) {
-  if (!console.error.calls) {
-    spyOn(console, 'error');
+  if (!console.warn.calls) {
+    spyOn(console, 'warn');
   } else {
-    console.error.calls.reset();
+    console.warn.calls.reset();
   }
   resetWarningCache();
 
   PropTypes.checkPropTypes(propTypes, object, 'prop', 'testComponent');
-  const callCount = console.error.calls.count();
+  const callCount = console.warn.calls.count();
   if (callCount > 1) {
     throw new Error('Too many warnings.');
   }
-  const message = console.error.calls.argsFor(0)[0] || null;
-  console.error.calls.reset();
+  const message = console.warn.calls.argsFor(0)[0] || null;
+  console.warn.calls.reset();
 
   return message;
 }
@@ -98,11 +98,11 @@ function expectWarningInDevelopment(declaration, value) {
   for (let i = 0; i < 3; i++) {
     declaration(props, propName, componentName, 'prop');
   }
-  expect(console.error.calls.count()).toBe(1);
-  expect(console.error.calls.argsFor(0)[0]).toContain(
+  expect(console.warn.calls.count()).toBe(1);
+  expect(console.warn.calls.argsFor(0)[0]).toContain(
     'You are manually calling a React.PropTypes validation ',
   );
-  console.error.calls.reset();
+  console.warn.calls.reset();
 }
 
 describe('PropTypesDevelopmentReact15', () => {
@@ -112,7 +112,7 @@ describe('PropTypesDevelopmentReact15', () => {
 
   describe('checkPropTypes', () => {
     it('should warn for invalid validators', () => {
-      spyOn(console, 'error')
+      spyOn(console, 'warn')
       const propTypes = { foo: undefined };
       const props = { foo: 'foo' };
       PropTypes.checkPropTypes(
@@ -122,14 +122,14 @@ describe('PropTypesDevelopmentReact15', () => {
         'testComponent',
         null,
       );
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
+      expect(console.warn.calls.argsFor(0)[0]).toEqual(
         'Warning: Failed prop type: testComponent: prop type `foo` is invalid; ' +
         'it must be a function, usually from the `prop-types` package, but received `undefined`.'
       );
     });
 
     it('does not return a value from a validator', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       const propTypes = {
         foo(props, propName, componentName) {
           return new Error('some error');
@@ -143,12 +143,12 @@ describe('PropTypesDevelopmentReact15', () => {
         'testComponent',
         null,
       );
-      expect(console.error.calls.argsFor(0)[0]).toContain('some error');
+      expect(console.warn.calls.argsFor(0)[0]).toContain('some error');
       expect(returnValue).toBe(undefined);
     });
 
     it('does not throw if validator throws', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       const propTypes = {
         foo(props, propName, componentName) {
           throw new Error('some error');
@@ -162,18 +162,18 @@ describe('PropTypesDevelopmentReact15', () => {
         'testComponent',
         null,
       );
-      expect(console.error.calls.argsFor(0)[0]).toContain('some error');
+      expect(console.warn.calls.argsFor(0)[0]).toContain('some error');
       expect(returnValue).toBe(undefined);
     });
 
     it('warns if any of the propTypes is not a function', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       const propTypes = {
         foo: PropTypes.invalid_type,
       };
       const props = { foo: 'foo' };
       const returnValue = PropTypes.checkPropTypes(propTypes, props, 'prop', 'testComponent', null);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
+      expect(console.warn.calls.argsFor(0)[0]).toEqual(
         'Warning: Failed prop type: testComponent: prop type `foo` is invalid; '
         + 'it must be a function, usually from the `prop-types` package, but received `undefined`.'
       );
@@ -252,7 +252,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.array, /please/);
       expectWarningInDevelopment(PropTypes.array, []);
       expectWarningInDevelopment(PropTypes.array.isRequired, /please/);
@@ -316,7 +316,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.any, null);
       expectWarningInDevelopment(PropTypes.any.isRequired, null);
       expectWarningInDevelopment(PropTypes.any.isRequired, undefined);
@@ -412,7 +412,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.arrayOf({foo: PropTypes.string}), {
         foo: 'bar',
       });
@@ -479,7 +479,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.element, [<div />, <div />]);
       expectWarningInDevelopment(PropTypes.element, <div />);
       expectWarningInDevelopment(PropTypes.element, 123);
@@ -578,7 +578,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.instanceOf(Date), {});
       expectWarningInDevelopment(PropTypes.instanceOf(Date), new Date());
       expectWarningInDevelopment(PropTypes.instanceOf(Date).isRequired, {});
@@ -678,7 +678,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.node, 'node');
       expectWarningInDevelopment(PropTypes.node, {});
       expectWarningInDevelopment(PropTypes.node.isRequired, 'node');
@@ -793,7 +793,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.objectOf({foo: PropTypes.string}), {
         foo: 'bar',
       });
@@ -813,12 +813,12 @@ describe('PropTypesDevelopmentReact15', () => {
 
   describe('OneOf Types', () => {
     it('should warn but not error for invalid argument', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       PropTypes.oneOf('red', 'blue');
 
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0]).toContain(
+      expect(console.warn).toHaveBeenCalled();
+      expect(console.warn.calls.argsFor(0)[0]).toContain(
         'Invalid argument supplied to oneOf, expected an instance of array.',
       );
 
@@ -868,7 +868,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), true);
       expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), null);
       expectWarningInDevelopment(PropTypes.oneOf(['red', 'blue']), undefined);
@@ -877,12 +877,12 @@ describe('PropTypesDevelopmentReact15', () => {
 
   describe('Union Types', () => {
     it('should warn but not error for invalid argument', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       PropTypes.oneOfType(PropTypes.string, PropTypes.number);
 
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0]).toContain(
+      expect(console.warn).toHaveBeenCalled();
+      expect(console.warn.calls.argsFor(0)[0]).toContain(
         'Invalid argument supplied to oneOfType, expected an instance of array.',
       );
 
@@ -890,7 +890,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn but for invalid argument type', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       const types = [undefined, null, false, new Date, /foo/, {}];
       const expected = ['undefined', 'null', 'a boolean', 'a date', 'a regexp', 'an object'];
@@ -898,12 +898,12 @@ describe('PropTypesDevelopmentReact15', () => {
       for (let i = 0; i < expected.length; i++) {
         const type = types[i];
         PropTypes.oneOfType([type]);
-        expect(console.error).toHaveBeenCalled();
-        expect(console.error.calls.argsFor(0)[0]).toContain(
+        expect(console.warn).toHaveBeenCalled();
+        expect(console.warn.calls.argsFor(0)[0]).toContain(
           'Invalid argument supplied to oneOfType. Expected an array of check functions, ' +
           'but received ' + expected[i] + ' at index 0.'
         );
-        console.error.calls.reset();
+        console.warn.calls.reset();
       }
 
       typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
@@ -959,7 +959,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         [],
@@ -1057,7 +1057,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.shape({}), 'some string');
       expectWarningInDevelopment(PropTypes.shape({foo: PropTypes.number}), {
         foo: 42,
@@ -1164,7 +1164,7 @@ describe('PropTypesDevelopmentReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectWarningInDevelopment(PropTypes.exact({}), 'some string');
       expectWarningInDevelopment(PropTypes.exact({foo: PropTypes.number}), {
         foo: 42,

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -20,20 +20,20 @@ function resetWarningCache() {
 }
 
 function getPropTypeWarningMessage(propTypes, object, componentName) {
-  if (!console.error.calls) {
-    spyOn(console, 'error');
+  if (!console.warn.calls) {
+    spyOn(console, 'warn');
   } else {
-    console.error.calls.reset();
+    console.warn.calls.reset();
   }
   resetWarningCache();
 
   PropTypes.checkPropTypes(propTypes, object, 'prop', 'testComponent');
-  const callCount = console.error.calls.count();
+  const callCount = console.warn.calls.count();
   if (callCount > 1) {
     throw new Error('Too many warnings.');
   }
-  const message = console.error.calls.argsFor(0)[0] || null;
-  console.error.calls.reset();
+  const message = console.warn.calls.argsFor(0)[0] || null;
+  console.warn.calls.reset();
 
   return message;
 }
@@ -108,7 +108,7 @@ describe('PropTypesDevelopmentStandalone', () => {
 
   describe('checkPropTypes', () => {
     it('should warn for invalid validators', () => {
-      spyOn(console, 'error')
+      spyOn(console, 'warn')
       const propTypes = { foo: undefined };
       const props = { foo: 'foo' };
       PropTypes.checkPropTypes(
@@ -118,14 +118,14 @@ describe('PropTypesDevelopmentStandalone', () => {
         'testComponent',
         null,
       );
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
+      expect(console.warn.calls.argsFor(0)[0]).toEqual(
         'Warning: Failed prop type: testComponent: prop type `foo` is invalid; ' +
         'it must be a function, usually from the `prop-types` package, but received `undefined`.'
       );
     });
 
     it('does not return a value from a validator', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       const propTypes = {
         foo(props, propName, componentName) {
           return new Error('some error');
@@ -139,12 +139,12 @@ describe('PropTypesDevelopmentStandalone', () => {
         'testComponent',
         null,
       );
-      expect(console.error.calls.argsFor(0)[0]).toContain('some error');
+      expect(console.warn.calls.argsFor(0)[0]).toContain('some error');
       expect(returnValue).toBe(undefined);
     });
 
     it('does not throw if validator throws', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       const propTypes = {
         foo(props, propName, componentName) {
           throw new Error('some error');
@@ -158,18 +158,18 @@ describe('PropTypesDevelopmentStandalone', () => {
         'testComponent',
         null,
       );
-      expect(console.error.calls.argsFor(0)[0]).toContain('some error');
+      expect(console.warn.calls.argsFor(0)[0]).toContain('some error');
       expect(returnValue).toBe(undefined);
     });
 
     it('warns if any of the propTypes is not a function', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       const propTypes = {
         foo: PropTypes.invalid_type,
       };
       const props = { foo: 'foo' };
       const returnValue = PropTypes.checkPropTypes(propTypes, props, 'prop', 'testComponent', null);
-      expect(console.error.calls.argsFor(0)[0]).toEqual(
+      expect(console.warn.calls.argsFor(0)[0]).toEqual(
         'Warning: Failed prop type: testComponent: prop type `foo` is invalid; '
         + 'it must be a function, usually from the `prop-types` package, but received `undefined`.'
       );
@@ -248,7 +248,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(PropTypes.array, /please/);
       expectThrowsInDevelopment(PropTypes.array, []);
       expectThrowsInDevelopment(PropTypes.array.isRequired, /please/);
@@ -312,7 +312,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(PropTypes.any, null);
       expectThrowsInDevelopment(PropTypes.any.isRequired, null);
       expectThrowsInDevelopment(PropTypes.any.isRequired, undefined);
@@ -408,7 +408,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(PropTypes.arrayOf({foo: PropTypes.string}), {
         foo: 'bar',
       });
@@ -475,7 +475,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(PropTypes.element, [<div />, <div />]);
       expectThrowsInDevelopment(PropTypes.element, <div />);
       expectThrowsInDevelopment(PropTypes.element, 123);
@@ -574,7 +574,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(PropTypes.instanceOf(Date), {});
       expectThrowsInDevelopment(PropTypes.instanceOf(Date), new Date());
       expectThrowsInDevelopment(PropTypes.instanceOf(Date).isRequired, {});
@@ -674,7 +674,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(PropTypes.node, 'node');
       expectThrowsInDevelopment(PropTypes.node, {});
       expectThrowsInDevelopment(PropTypes.node.isRequired, 'node');
@@ -795,7 +795,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(PropTypes.objectOf({foo: PropTypes.string}), {
         foo: 'bar',
       });
@@ -815,12 +815,12 @@ describe('PropTypesDevelopmentStandalone', () => {
 
   describe('OneOf Types', () => {
     it('should warn but not error for invalid argument', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       PropTypes.oneOf('red', 'blue');
 
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0]).toContain(
+      expect(console.warn).toHaveBeenCalled();
+      expect(console.warn.calls.argsFor(0)[0]).toContain(
         'Invalid argument supplied to oneOf, expected an instance of array.',
       );
 
@@ -870,7 +870,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(PropTypes.oneOf(['red', 'blue']), true);
       expectThrowsInDevelopment(PropTypes.oneOf(['red', 'blue']), null);
       expectThrowsInDevelopment(PropTypes.oneOf(['red', 'blue']), undefined);
@@ -879,12 +879,12 @@ describe('PropTypesDevelopmentStandalone', () => {
 
   describe('Union Types', () => {
     it('should warn but not error for invalid argument', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       PropTypes.oneOfType(PropTypes.string, PropTypes.number);
 
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0]).toContain(
+      expect(console.warn).toHaveBeenCalled();
+      expect(console.warn.calls.argsFor(0)[0]).toContain(
         'Invalid argument supplied to oneOfType, expected an instance of array.',
       );
 
@@ -892,7 +892,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn but for invalid argument type', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       const types = [undefined, null, false, new Date, /foo/, {}];
       const expected = ['undefined', 'null', 'a boolean', 'a date', 'a regexp', 'an object'];
@@ -900,12 +900,12 @@ describe('PropTypesDevelopmentStandalone', () => {
       for (let i = 0; i < expected.length; i++) {
         const type = types[i];
         PropTypes.oneOfType([type]);
-        expect(console.error).toHaveBeenCalled();
-        expect(console.error.calls.argsFor(0)[0]).toContain(
+        expect(console.warn).toHaveBeenCalled();
+        expect(console.warn.calls.argsFor(0)[0]).toContain(
           'Invalid argument supplied to oneOfType. Expected an array of check functions, ' +
           'but received ' + expected[i] + ' at index 0.'
         );
-        console.error.calls.reset();
+        console.warn.calls.reset();
       }
 
       typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
@@ -961,7 +961,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         [],
@@ -1059,7 +1059,7 @@ describe('PropTypesDevelopmentStandalone', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectThrowsInDevelopment(PropTypes.shape({}), 'some string');
       expectThrowsInDevelopment(PropTypes.shape({foo: PropTypes.number}), {
         foo: 42,

--- a/__tests__/PropTypesProductionReact15-test.js
+++ b/__tests__/PropTypesProductionReact15-test.js
@@ -24,10 +24,10 @@ function resetWarningCache() {
 }
 
 function expectNoop(declaration, value) {
-  if (!console.error.calls) {
-    spyOn(console, 'error');
+  if (!console.warn.calls) {
+    spyOn(console, 'warn');
   } else {
-    console.error.calls.reset();
+    console.warn.calls.reset();
   }
 
   const props = {testProp: value};
@@ -44,8 +44,8 @@ function expectNoop(declaration, value) {
   PropTypes.checkPropTypes(propTypes, props, 'prop', 'testComponent');
 
   // They should all be no-ops
-  expect(console.error.calls.count()).toBe(0);
-  console.error.calls.reset();
+  expect(console.warn.calls.count()).toBe(0);
+  console.warn.calls.reset();
 }
 
 describe('PropTypesProductionReact15', () => {
@@ -124,7 +124,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(PropTypes.array, /please/);
       expectNoop(PropTypes.array, []);
       expectNoop(PropTypes.array.isRequired, /please/);
@@ -188,7 +188,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(PropTypes.any, null);
       expectNoop(PropTypes.any.isRequired, null);
       expectNoop(PropTypes.any.isRequired, undefined);
@@ -284,7 +284,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(PropTypes.arrayOf({foo: PropTypes.string}), {
         foo: 'bar',
       });
@@ -351,7 +351,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(PropTypes.element, [<div />, <div />]);
       expectNoop(PropTypes.element, <div />);
       expectNoop(PropTypes.element, 123);
@@ -450,7 +450,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(PropTypes.instanceOf(Date), {});
       expectNoop(PropTypes.instanceOf(Date), new Date());
       expectNoop(PropTypes.instanceOf(Date).isRequired, {});
@@ -550,7 +550,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(PropTypes.node, 'node');
       expectNoop(PropTypes.node, {});
       expectNoop(PropTypes.node.isRequired, 'node');
@@ -665,7 +665,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(PropTypes.objectOf({foo: PropTypes.string}), {
         foo: 'bar',
       });
@@ -685,11 +685,11 @@ describe('PropTypesProductionReact15', () => {
 
   describe('OneOf Types', () => {
     it('should ignore invalid argument', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       PropTypes.oneOf('red', 'blue');
 
-      expect(console.error).not.toHaveBeenCalled();
+      expect(console.warn).not.toHaveBeenCalled();
       expectNoop(PropTypes.oneOf('red', 'blue'), 'red');
     });
 
@@ -736,7 +736,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(PropTypes.oneOf(['red', 'blue']), true);
       expectNoop(PropTypes.oneOf(['red', 'blue']), null);
       expectNoop(PropTypes.oneOf(['red', 'blue']), undefined);
@@ -745,11 +745,11 @@ describe('PropTypesProductionReact15', () => {
 
   describe('Union Types', () => {
     it('should ignore invalid argument', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       PropTypes.oneOfType(PropTypes.string, PropTypes.number);
 
-      expect(console.error).not.toHaveBeenCalled();
+      expect(console.warn).not.toHaveBeenCalled();
       expectNoop(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
     });
 
@@ -803,7 +803,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         [],
@@ -912,7 +912,7 @@ describe('PropTypesProductionReact15', () => {
     });
 
     it('should warn if called manually in development', () => {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
       expectNoop(PropTypes.shape({}), 'some string');
       expectNoop(PropTypes.shape({foo: PropTypes.number}), {
         foo: 42,

--- a/__tests__/PropTypesProductionStandalone-test.js
+++ b/__tests__/PropTypesProductionStandalone-test.js
@@ -30,19 +30,19 @@ describe('PropTypesProductionStandalone', function() {
   });
 
   function getPropTypeWarningMessage(propTypes, object, componentName) {
-    if (!console.error.calls) {
-      spyOn(console, 'error');
+    if (!console.warn.calls) {
+      spyOn(console, 'warn');
     } else {
-      console.error.calls.reset();
+      console.warn.calls.reset();
     }
     resetWarningCache();
     PropTypes.checkPropTypes(propTypes, object, 'prop', 'testComponent');
-    const callCount = console.error.calls.count();
+    const callCount = console.warn.calls.count();
     if (callCount > 1) {
       throw new Error('Too many warnings.');
     }
-    const message = console.error.calls.argsFor(0)[0] || null;
-    console.error.calls.reset();
+    const message = console.warn.calls.argsFor(0)[0] || null;
+    console.warn.calls.reset();
 
     return message;
   }
@@ -224,7 +224,7 @@ describe('PropTypesProductionStandalone', function() {
 
   describe('checkPropTypes', function() {
     it('does not call validators', function() {
-      spyOn(console, 'error');
+      spyOn(console, 'warn');
 
       const spy = jest.fn();
       typeCheckPass(PropTypes.string, 42);

--- a/checkPropTypes.js
+++ b/checkPropTypes.js
@@ -16,7 +16,7 @@ if (process.env.NODE_ENV !== 'production') {
   printWarning = function(text) {
     var message = 'Warning: ' + text;
     if (typeof console !== 'undefined') {
-      console.error(message);
+      console.warn(message);
     }
     try {
       // --- Welcome to debugging React ---

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -19,7 +19,7 @@ if (process.env.NODE_ENV !== 'production') {
   printWarning = function(text) {
     var message = 'Warning: ' + text;
     if (typeof console !== 'undefined') {
-      console.error(message);
+      console.warn(message);
     }
     try {
       // --- Welcome to debugging React ---


### PR DESCRIPTION
Checking the prop types does not change how the program will actually work, and I believe that's why all invalid props are reported with a _Warning_ message.

Yet, these messages are output using `console.error`, and this log level clearly conflicts with the message idea.

This PR replaces all those calls with `console.warn`, bringing consistency to the log levels.