### PR TITLE
refactor: extract has and warning

### DIFF
--- a/checkPropTypes.js
+++ b/checkPropTypes.js
@@ -12,7 +12,7 @@ var printWarning = function() {};
 if (process.env.NODE_ENV !== 'production') {
   var ReactPropTypesSecret = require('./lib/ReactPropTypesSecret');
   var loggedTypeFailures = {};
-  var has = Function.call.bind(Object.prototype.hasOwnProperty);
+  var has = require('./lib/has');
 
   printWarning = function(text) {
     var message = 'Warning: ' + text;

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -11,9 +11,9 @@ var ReactIs = require('react-is');
 var assign = require('object-assign');
 
 var ReactPropTypesSecret = require('./lib/ReactPropTypesSecret');
+var has = require('./lib/has');
 var checkPropTypes = require('./checkPropTypes');
 
-var has = Function.call.bind(Object.prototype.hasOwnProperty);
 var printWarning = function() {};
 
 if (process.env.NODE_ENV !== 'production') {

--- a/lib/has.js
+++ b/lib/has.js
@@ -1,0 +1,1 @@
+module.exports = Function.call.bind(Object.prototype.hasOwnProperty);


### PR DESCRIPTION
According to DRY, extract `has` and `warning` message to lib as well as making the failing tests pass.