### PR TITLE
[Tests] Fixed typo: 'Any type *should* accept any value'

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -401,7 +401,7 @@ describe('PropTypesDevelopmentReact15', () => {
   });
 
   describe('Any type', () => {
-    it('should should accept any value', () => {
+    it('should accept any value', () => {
       typeCheckPass(PropTypes.any, 0);
       typeCheckPass(PropTypes.any, 'str');
       typeCheckPass(PropTypes.any, []);

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -398,7 +398,7 @@ describe('PropTypesDevelopmentStandalone', () => {
   });
 
   describe('Any type', () => {
-    it('should should accept any value', () => {
+    it('should accept any value', () => {
       typeCheckPass(PropTypes.any, 0);
       typeCheckPass(PropTypes.any, 'str');
       typeCheckPass(PropTypes.any, []);

--- a/__tests__/PropTypesProductionReact15-test.js
+++ b/__tests__/PropTypesProductionReact15-test.js
@@ -177,7 +177,7 @@ describe('PropTypesProductionReact15', () => {
   });
 
   describe('Any type', () => {
-    it('should should accept any value', () => {
+    it('should accept any value', () => {
       expectNoop(PropTypes.any, 0);
       expectNoop(PropTypes.any, 'str');
       expectNoop(PropTypes.any, []);


### PR DESCRIPTION
I just found this typo that effected three files in \_\_tests\_\_. I believe The first "Any type" test should be "should accept any value" and not "should should accept any value"