### PR TITLE
Add key to error messages

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -251,6 +251,27 @@ describe('PropTypesDevelopmentReact15', () => {
       expectInvalidValidatorWarning(PropTypes.exact({ bar: 'true' }), 'string');
       expectInvalidValidatorWarning(PropTypes.exact({ bar: null }), 'null');
     });
+
+    it('should output the value of the `key` prop (if it has one)', () => {
+      function typeCheckFailWithKey(declaration, value) {
+        const propTypes = { testProp: declaration };
+        const props = { testProp: value, key: 'abc' };
+        const message = getPropTypeWarningMessage(propTypes, props, 'testComponent');
+        expect(message).toContain('`testComponent` with key `abc`');
+      }
+      function Something() {}
+      typeCheckFailWithKey(PropTypes.string, false);
+      typeCheckFailWithKey(PropTypes.arrayOf(PropTypes.string), 2);
+      typeCheckFailWithKey(PropTypes.element, {});
+      typeCheckFailWithKey(PropTypes.elementType, {});
+      typeCheckFailWithKey(PropTypes.instanceOf(Something), '');
+      typeCheckFailWithKey(PropTypes.node, {});
+      typeCheckFailWithKey(PropTypes.objectOf(PropTypes.string), '');
+      typeCheckFailWithKey(PropTypes.oneOf([1]), '');
+      typeCheckFailWithKey(PropTypes.oneOfType([PropTypes.number]), '');
+      typeCheckFailWithKey(PropTypes.shape({ a: PropTypes.string }), false);
+      typeCheckFailWithKey(PropTypes.exact({ a: PropTypes.string }), false);
+    });
   });
 
   describe('resetWarningCache', () => {
@@ -1217,7 +1238,7 @@ describe('PropTypesDevelopmentReact15', () => {
       typeCheckFail(
         PropTypes.shape({key: PropTypes.number}),
         {key: 'abc'},
-        'Invalid prop `testProp.key` of type `string` supplied to `testComponent`, ' +
+        'Invalid prop `testProp.key` of type `string` supplied to `testComponent` with key `abc`, ' +
           'expected `number`.',
       );
     });
@@ -1324,7 +1345,7 @@ describe('PropTypesDevelopmentReact15', () => {
       typeCheckFail(
         PropTypes.exact({key: PropTypes.number}),
         {key: 'abc'},
-        'Invalid prop `testProp.key` of type `string` supplied to `testComponent`, ' +
+        'Invalid prop `testProp.key` of type `string` supplied to `testComponent` with key `abc`, ' +
           'expected `number`.',
       );
     });

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -1291,7 +1291,7 @@ describe('PropTypesDevelopmentStandalone', () => {
       typeCheckFail(
         PropTypes.shape({key: PropTypes.number}),
         {key: 'abc'},
-        'Invalid prop `testProp.key` of type `string` supplied to `testComponent`, ' +
+        'Invalid prop `testProp.key` of type `string` supplied to `testComponent` with key `abc`, ' +
           'expected `number`.',
       );
     });

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -35,6 +35,11 @@ function emptyFunctionThatReturnsNull() {
   return null;
 }
 
+// Helper for adding `key` to the error message if it exists in props.
+function getKey(props) {
+  return (props.key && typeof props.key !== 'obejct') ? ' with key `' + props.key + '`' : '';
+}
+
 module.exports = function(isValidElement, throwOnDirectAccess) {
   /* global Symbol */
   var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
@@ -209,9 +214,9 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       if (props[propName] == null) {
         if (isRequired) {
           if (props[propName] === null) {
-            return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`, but its value is `null`.'));
+            return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`' + getKey(props) + ', but its value is `null`.'));
           }
-          return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`, but its value is `undefined`.'));
+          return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`' + getKey(props) + ', but its value is `undefined`.'));
         }
         return null;
       } else {
@@ -236,7 +241,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
         var preciseType = getPreciseType(propValue);
 
         return new PropTypeError(
-          'Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + preciseType + '` supplied to `' + componentName + '`, expected ') + ('`' + expectedType + '`.'),
+          'Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + preciseType + '` supplied to `' + componentName + '`' + getKey(props) + ', expected ') + ('`' + expectedType + '`.'),
           {expectedType: expectedType}
         );
       }
@@ -257,7 +262,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       var propValue = props[propName];
       if (!Array.isArray(propValue)) {
         var propType = getPropType(propValue);
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an array.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`' + getKey(props) + ', expected an array.'));
       }
       for (var i = 0; i < propValue.length; i++) {
         var error = typeChecker(propValue, i, componentName, location, propFullName + '[' + i + ']', ReactPropTypesSecret);
@@ -275,7 +280,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       var propValue = props[propName];
       if (!isValidElement(propValue)) {
         var propType = getPropType(propValue);
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`' + getKey(props) + ', expected a single ReactElement.'));
       }
       return null;
     }
@@ -287,7 +292,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       var propValue = props[propName];
       if (!ReactIs.isValidElementType(propValue)) {
         var propType = getPropType(propValue);
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement type.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`' + getKey(props) + ', expected a single ReactElement type.'));
       }
       return null;
     }
@@ -299,7 +304,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       if (!(props[propName] instanceof expectedClass)) {
         var expectedClassName = expectedClass.name || ANONYMOUS;
         var actualClassName = getClassName(props[propName]);
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + actualClassName + '` supplied to `' + componentName + '`, expected ') + ('instance of `' + expectedClassName + '`.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + actualClassName + '` supplied to `' + componentName + '`' + getKey(props) + ', expected ') + ('instance of `' + expectedClassName + '`.'));
       }
       return null;
     }
@@ -336,7 +341,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
         }
         return value;
       });
-      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + String(propValue) + '` ' + ('supplied to `' + componentName + '`, expected one of ' + valuesString + '.'));
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + String(propValue) + '` ' + ('supplied to `' + componentName + '`' + getKey(props) + ', expected one of ' + valuesString + '.'));
     }
     return createChainableTypeChecker(validate);
   }
@@ -349,7 +354,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       var propValue = props[propName];
       var propType = getPropType(propValue);
       if (propType !== 'object') {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an object.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`' + getKey(props) + ', expected an object.'));
       }
       for (var key in propValue) {
         if (has(propValue, key)) {
@@ -394,7 +399,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
         }
       }
       var expectedTypesMessage = (expectedTypes.length > 0) ? ', expected one of type [' + expectedTypes.join(', ') + ']': '';
-      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`' + expectedTypesMessage + '.'));
+      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`' + getKey(props) + expectedTypesMessage + '.'));
     }
     return createChainableTypeChecker(validate);
   }
@@ -402,7 +407,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
   function createNodeChecker() {
     function validate(props, propName, componentName, location, propFullName) {
       if (!isNode(props[propName])) {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`, expected a ReactNode.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`' + getKey(props) + ', expected a ReactNode.'));
       }
       return null;
     }
@@ -421,7 +426,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       var propValue = props[propName];
       var propType = getPropType(propValue);
       if (propType !== 'object') {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`' + getKey(props) + ', expected `object`.'));
       }
       for (var key in shapeTypes) {
         var checker = shapeTypes[key];
@@ -443,7 +448,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       var propValue = props[propName];
       var propType = getPropType(propValue);
       if (propType !== 'object') {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
+        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`' + getKey(props) + ', expected `object`.'));
       }
       // We need to check all keys in case some are required but missing from
       // props.
@@ -455,7 +460,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
         }
         if (!checker) {
           return new PropTypeError(
-            'Invalid ' + location + ' `' + propFullName + '` key `' + key + '` supplied to `' + componentName + '`.' +
+            'Invalid ' + location + ' `' + propFullName + '` key `' + key + '` supplied to `' + componentName + '`' + getKey(props) + '.' +
             '\nBad object: ' + JSON.stringify(props[propName], null, '  ') +
             '\nValid keys: ' +  JSON.stringify(Object.keys(shapeTypes), null, '  ')
           );


### PR DESCRIPTION
Fixes #279 

This PR aims to solve the problem of having many failed propTypes checks when rendering a huge list of components. In this case, it can be really hard to determine which warning belongs to which component instance, making debugging tedious and frustrating.

Displaying the `key` in warnings could help to quickly identify which item(s) in a list of components have type warnings:

`Warning: Failed prop type: The prop 'blabla' is marked as required in 'SomeComponent' with key 'abc', but its value is 'null'.`

While this would mitigate the issue, I'm not a 100% sure that this is a good idea (see below), but I'm opening this PR in hopes of at least getting some discussion around it.

This solution should work decently when doing `array.map`, but it comes with at least one side effect that might not be desirable. As far as I know the `key` prop doesn't hold any special significance outside the case of `array.map` and might be used as a part of the regular data flow. In those cases it might be weird that the `key` prop is displayed in warnings. Detecting whether a component was rendered with `array.map` is likely impossible in `prop-types` so I don't see a way of avoiding this.

Also, there might be a need for truncating very long keys to avoid destroying the readability of the message?