### PR TITLE
Add a package `sideEffects` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "prop-types",
   "version": "15.7.2",
   "description": "Runtime type checking for React props and similar objects.",
+  "sideEffects": false,
   "main": "index.js",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
This PR adds a package `sideEffects` field with a `false` value. This allows tree-shaking and dead-code-elimination to work much better, eliminating imports of `prop-types` if all of the imports end up being unused.

- esbuild docs: https://esbuild.github.io/api/#manual-tree-shaking-annotations
- webpack docs: https://webpack.js.org/guides/tree-shaking

This change could significantly improve the bundle size of projects that nest `propTypes` under a conditional so they will be eliminated from a production bundle, for example:

https://github.com/jaydenseric/device-agnostic-ui/blob/89e5ba0b8c0ee5a8fb38f4ed74e7f19a6b4970d7/src/public/components/Button.js#L25-L32

```js
if (typeof process === 'object' && process.env.NODE_ENV !== 'production') {
  Button.displayName = 'Button';
  Button.propTypes = {
    disabled: PropTypes.bool,
    className: PropTypes.string,
    children: propTypeChildren.isRequired,
  };
}
```

Currently, because the `prop-types` package doesn't have a `"sideEffects": false` field, for a production bundle esbuild eliminates the `Button.propTypes = {` declaration but it leaves the `const PropTypes = require('prop-types');`.
