### PR TITLE
Additional ESLint rules & Fix typo in factoryWithTypeCheckers.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,10 @@
       },
       "rules": {
         "no-unused-vars": "off",
+        "no-multi-spaces": [
+          "error"
+        ],
+        "key-spacing": ["error"],
       },
       "parserOptions": {
         "ecmaVersion": 2019,

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,9 +20,7 @@
       },
       "rules": {
         "no-unused-vars": "off",
-        "no-multi-spaces": [
-          "error"
-        ],
+        "no-multi-spaces": ["error"],
         "key-spacing": ["error"],
       },
       "parserOptions": {

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -196,7 +196,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
           ) {
             printWarning(
               'You are manually calling a React.PropTypes validation ' +
-              'function for the `' + propFullName + '` prop on `' + componentName  + '`. This is deprecated ' +
+              'function for the `' + propFullName + '` prop on `' + componentName + '`. This is deprecated ' +
               'and will throw in the standalone `prop-types` package. ' +
               'You may be seeing this warning due to a third-party PropTypes ' +
               'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.'
@@ -445,8 +445,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       if (propType !== 'object') {
         return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
       }
-      // We need to check all keys in case some are required but missing from
-      // props.
+      // We need to check all keys in case some are required but missing from props.
       var allKeys = assign({}, props[propName], shapeTypes);
       for (var key in allKeys) {
         var checker = shapeTypes[key];
@@ -457,7 +456,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
           return new PropTypeError(
             'Invalid ' + location + ' `' + propFullName + '` key `' + key + '` supplied to `' + componentName + '`.' +
             '\nBad object: ' + JSON.stringify(props[propName], null, '  ') +
-            '\nValid keys: ' +  JSON.stringify(Object.keys(shapeTypes), null, '  ')
+            '\nValid keys: ' + JSON.stringify(Object.keys(shapeTypes), null, '  ')
           );
         }
         var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);


### PR DESCRIPTION
I've improved the documentation to fix some minor typos in this PR

Additional ESLint rules:  "no-multi-spaces": ["error"], "key-spacing": ["error"]
"no-multi-spaces" - Disallow multiple spaces;
"key-spacing" - Enforce consistent spacing between keys and values in object literal properties;