### PR TITLE
[eslint] enable some rules 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+prop-types.min.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,8 @@
   },
   "rules": {
     "no-console": "off",
+    "no-multi-spaces": ["error"],
+    "key-spacing": ["error"],
   },
   "overrides": [
     {

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -196,7 +196,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
           ) {
             printWarning(
               'You are manually calling a React.PropTypes validation ' +
-              'function for the `' + propFullName + '` prop on `' + componentName  + '`. This is deprecated ' +
+              'function for the `' + propFullName + '` prop on `' + componentName + '`. This is deprecated ' +
               'and will throw in the standalone `prop-types` package. ' +
               'You may be seeing this warning due to a third-party PropTypes ' +
               'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.'
@@ -445,8 +445,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       if (propType !== 'object') {
         return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
       }
-      // We need to check all keys in case some are required but missing from
-      // props.
+      // We need to check all keys in case some are required but missing from props.
       var allKeys = assign({}, props[propName], shapeTypes);
       for (var key in allKeys) {
         var checker = shapeTypes[key];
@@ -457,7 +456,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
           return new PropTypeError(
             'Invalid ' + location + ' `' + propFullName + '` key `' + key + '` supplied to `' + componentName + '`.' +
             '\nBad object: ' + JSON.stringify(props[propName], null, '  ') +
-            '\nValid keys: ' +  JSON.stringify(Object.keys(shapeTypes), null, '  ')
+            '\nValid keys: ' + JSON.stringify(Object.keys(shapeTypes), null, '  ')
           );
         }
         var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret);


### PR DESCRIPTION
Hello,
I've  improved the documentation by adding additional ESLint rules and fixing some minor typos.

Additional ESLint rules: "no-multi-spaces": ["error"], "key-spacing": ["error"]
"no-multi-spaces" - Disallow multiple spaces;
"key-spacing" - Enforce consistent spacing between keys and values in object literal properties;